### PR TITLE
feat(lore): Arcanea Monster System + Nethyssa Leviathan + Hermes pipeline

### DIFF
--- a/.agent/active-agents.md
+++ b/.agent/active-agents.md
@@ -1,0 +1,53 @@
+# Active Agent Coordination Ledger
+
+*Protocol: AGENTS.md §4 — Read before taking any branch scope.*
+
+---
+
+## Current Session
+
+Branch: `claude/arcanea-kraken-monster-system-t24p73`
+Started: 2026-06-22
+
+| Agent | Harness | Scope | Status |
+|---|---|---|---|
+| Claude | Claude Code | Conductor: canon/lore/gen/data/CI | active |
+| Codex | OpenAI Codex | Executor: tools/skills/tests (assigned partitions) | active |
+
+---
+
+## Scope Partitions
+
+**Claude (conductor) owns:**
+- `.arcanea/lore/**` — all canon files
+- `.arcanea/gen/**` — prompt packs, harness routing, lanes
+- `.arcanea/intake/**` — capture types, producers, spectrum
+- `packages/arcanea-mcp/src/data/**` — creature data (bestiary, leviathans, atlas)
+- `.claude/**` — skills, agents, commands
+- `.agent/**` — this ledger
+- CI: `.github/workflows/**`
+
+**Codex (executor) may take:**
+- `packages/arcanea-mcp/src/tools/**` — tool implementations
+- `packages/arcanea-mcp/src/skills/**` — skill implementations
+- `packages/arcanea-mcp/tests/**` — test files
+- Any path Claude explicitly delegates in a commit message or PR description
+
+---
+
+## Integration Protocol
+
+1. Each agent commits only to its own scope
+2. No force-pushes, no amends to another agent's commits
+3. Claude reviews Codex commits before any canon-adjacent files are touched
+4. Disputed paths → open an issue tagged `agent-conflict` and wait for Frank
+
+---
+
+## File Lock Registry
+
+| File / Glob | Locked by | Since |
+|---|---|---|
+| `.arcanea/lore/**` | Claude | 2026-06-22 |
+| `.arcanea/gen/**` | Claude | 2026-06-22 |
+| `packages/arcanea-mcp/src/data/**` | Claude | 2026-06-22 |

--- a/.arcanea/WORKFLOWS.md
+++ b/.arcanea/WORKFLOWS.md
@@ -1,0 +1,119 @@
+# Arcanea Workflows
+
+The three recurring loops that move work from idea to live artifact, each wired to the gates that already exist (`canon-check`, `lock-decision`, the visual-creation council). Nethyssa — the first Leviathan, a Wild Godbeast outside the ten Gates — is the worked example threading all three.
+
+The loops compose: a new canonical entity is **locked** in the lore loop, **rendered** in the asset loop, then **minted** in the web3 loop. Lore gates upstream of asset gates upstream of web3 — you never mint what isn't approved, never approve what isn't locked.
+
+---
+
+## 1. Lore loop — idea → STAGING → LOCKED
+
+New canon enters as STAGING and only becomes LOCKED by Frank's explicit decision. Nothing downstream (assets, mints) treats a STAGING entity as final.
+
+```
+ 1. Hermes intake     a lore idea arrives (note, transcript, request)
+        │
+ 2. producers         lore producers draft the entity — name, class, role,
+        │             relationships, material
+        │
+ 3. canon-check       run `canon-check` — does it contradict CANON_LOCKED.md?
+        │             (cosmic duality, Five Elements, Ten Gates, ranks, Malachar)
+        │             fail → back to producers · pass → continue
+        │
+ 4. STAGING           written into CANON_LOCKED.md marked STAGING (provisional)
+        │
+ 5. lock-decision     `lock-decision` — Frank-gated. Only Frank promotes
+        │             STAGING → LOCKED.
+        ▼
+ 6. LOCKED            canon is final; downstream loops may treat it as real
+```
+
+**Nethyssa:** drafted as a Leviathan / Wild Godbeast (no Gate, no frequency), passes `canon-check` because she does not collide with the ten Gate Godbeasts, sits in CANON_LOCKED.md as **STAGING**. She is **not yet LOCKED** — so she may be rendered and minted on **testnet** as a worked example, but not promoted to mainnet canon until `lock-decision` lands.
+
+---
+
+## 2. Asset loop — prompt → generate → review → publish
+
+Image generation runs in external harnesses, never from Claude. The loop ends by updating the registry / `assets` table and logging the outcome back as learning.
+
+```
+ 1. prompt-pack       pull the prompt + brand/material constraints
+        │             (Nethyss Pearl palette for Nethyssa)
+        │
+ 2. harness route     route to the right engine:
+        │               Grok Imagine  /  Codex gpt-image-2  /  Antigravity NB2
+        │
+ 3. generate          harness renders the asset (Claude does NOT generate)
+        │
+ 4. DAM intake        Arcanea Hermes ingests file + gen sidecar →
+        │             Supabase bucket (arcanea-gallery) → one `assets` row
+        │             (status = 'pending')
+        │
+ 5. council review    visual-creation council (Brand Guardian / Art Director /
+        │             Storyteller) → APPROVED | NEEDS-REVISION | REJECTED
+        │             not-approved → back to step 1 (row kept, not deleted)
+        │
+ 6. approve           status 'pending' → 'review' → 'approved'
+        │
+ 7. publish           status → 'published'; RLS unlocks public read
+        │
+ 8. registry/assets   registry cache regenerates from published rows
+        │             (image-registry.ts becomes a generated cache — see DAM.md)
+        ▼
+ 9. outcome logged    result + council notes recorded as a learning-loop
+                      signal (what worked, what got rejected and why)
+```
+
+**Nethyssa:** prompt-pack carries the Nethyss Pearl material (abyssal nacre, teal-over-black); routed to a harness; ingested to `arcanea-gallery/leviathans/nethyssa-v1.webp` as category `leviathans`, `status='pending'`; council reviews; on approval, published; registry regenerates to include her. Asset path: `/leviathans/nethyssa-v1.webp`.
+
+---
+
+## 3. Web3 loop — approved asset → IPFS → mint → IP-register (testnet)
+
+Only an approved/published asset enters this loop. Everything stays on **Base Sepolia (84532)** — mainnet is Frank-gated, keys never in repo. The services are currently MOCKS (see arcanea-ai-app `apps/web/docs/WEB3-EXECUTION.md`).
+
+```
+ 1. approved asset    an `assets` row at status='approved'/'published'
+        │
+ 2. IPFS              pin image + metadata JSON → ipfs://<cid>
+        │
+ 3. mint              ERC-721 mint (1/1 for Leviathans/Gods) → tokenId
+        │
+ 4. IP-register       Story Protocol registerIPAsset(...) →
+        │             ipaAddress + PIL terms (1=Non-Commercial, 2=Commercial)
+        │             [testnet / mock today]
+        │
+ 5. audit + registry  append `asset_generations` row linking
+                      asset_id → cid → tokenId → ipaAddress → tx hash;
+                      update the registry/`assets` row with mint state
+```
+
+**Nethyssa:** as the first Leviathan 1/1 she runs this loop end to end on testnet — metadata with `Tier: Leviathan`, `Material: Nethyss Pearl`, `Gate: None`. The mint stays on Base Sepolia until her canon is LOCKED; the full lineage (generated → published → minted → IP-registered) is reconstructable from her `asset_id` via `asset_generations`.
+
+---
+
+## How the loops chain (Nethyssa end to end)
+
+```
+ LORE          canon-check pass → STAGING in CANON_LOCKED.md
+   │           (lock-decision pending — testnet only)
+   ▼
+ ASSET         /leviathans/nethyssa-v1.webp → council → published →
+   │           registry/assets updated
+   ▼
+ WEB3          IPFS → testnet mint (1/1) → Story IP-register →
+               asset_generations audit row
+```
+
+Gate order is load-bearing: **lock-decision** (Frank) gates promotion to real canon; **council** gates publish; **approved status** gates minting. Skip none of them.
+
+---
+
+## Cross-references
+
+- DAM pipeline + `assets` / `asset_generations` schema + Nethyss Pearl card: `arcanea-ai-app/apps/web/docs/DAM.md`
+- Web3 mock-vs-build + NFT collection spec: `arcanea-ai-app/apps/web/docs/WEB3-EXECUTION.md`
+- Canon source of truth: `.arcanea/lore/CANON_LOCKED.md`
+- Gates: `canon-check`, `lock-decision`, visual-creation council
+
+Built on SIP.

--- a/.arcanea/gen/HARNESS_ROUTING.md
+++ b/.arcanea/gen/HARNESS_ROUTING.md
@@ -1,0 +1,76 @@
+# Arcanea Image-Gen Harness Routing
+
+> How Arcanea image generation is routed across harnesses. Mirrors FrankX's `lib/gen`
+> substrate: the product is not any single model — it's the curated lanes + the routing
+> table + the council gate. Centralize on the routing layer, never on a vendor.
+
+---
+
+## The core mechanic
+
+**Claude Code does not generate images.** It emits ready-to-paste **prompt-packs** (see
+`prompt-packs/`) that the image-capable harnesses consume **in their own CLIs**. The lane
+(`lanes.ts`) carries the palette, prompt fragments, negative prompt, and quality bar; this
+file decides *which harness* paints it.
+
+Two rules sit above everything:
+
+1. **One lane per asset.** Pick a single `LaneId`, hold its `qualityBar`. Never mix lanes on one image.
+2. **Council-gate before any batch.** Run the council review (Brand / Art Director / Storyteller
+   lenses) on a single organic-first render before fanning out a batch. No batch generation before approval.
+
+---
+
+## The harnesses — when and how
+
+### 1. Grok Imagine — `grok-imagine`
+- **Where it runs:** inside the **Grok CLI / TUI** (SuperGrok-included, no extra API cost).
+- **When to use:** fast ideation and variation sweeps. First-pass exploration, "give me ten silhouettes," cheap iteration before committing to a hero render.
+- **How:** paste the lane prompt into Grok Imagine in the Grok TUI; generate variations; pick the strongest seed to carry forward.
+- **Strength:** speed and volume. **Weakness:** less reliable for legible text / fine typographic detail.
+
+### 2. Codex gpt-image-2 — `gpt-image-2`
+- **Where it runs:** inside **Codex**, via the `$imagegen` tool (counts toward the ChatGPT plan).
+- **When to use:** clean single renders — one polished hero, NFT 1/1, card art where you want a controlled, predictable result.
+- **How:** in Codex, invoke `$imagegen` with the lane positive prompt + negative prompt; one render at a time.
+- **Strength:** clean, controllable single images. **Weakness:** one-at-a-time, plan-metered.
+
+### 3. Antigravity / Gemini NB2 / Nano Banana Pro — `nano-banana-pro` · `nano-banana-2`
+- **Where it runs:** **Antigravity / Gemini** built-in (free preview engine).
+- **When to use:** lore-accurate and text-legible heroes. Search-grounded generation means labels, names, and technical/lore detail render legibly and accurately — the right call for guardian portraits, world-boss heroes, and anything carrying on-image text.
+- **How:** in Antigravity/Gemini, run the built-in image engine (Nano Banana Pro for best fidelity, NB2 for fast iteration) with the lane prompt; enable search grounding for lore-heavy renders.
+- **Strength:** legibility + grounding + free. **Weakness:** preview-tier availability can shift.
+
+### 4. Higgsfield MCP — `higgsfield`
+- **Where it runs:** via the **Higgsfield MCP** (paid).
+- **When to use:** **reserve for video**, or when a native subscription-included quota is exhausted. Not the default for stills.
+- **How:** call the Higgsfield MCP tools (`generate_image` / `generate_video`) with the lane prompt; mind the credit cost.
+- **Strength:** cinematic motion + frontier models. **Weakness:** paid — last resort for stills.
+
+**Default order of preference for stills:** native subscription-included engines first
+(Grok Imagine for ideation → NB Pro / gpt-image-2 for heroes), Higgsfield only for video or when a native quota runs out.
+
+---
+
+## Lane → harness table
+
+| Lane (`LaneId`)       | Primary harness                          | Fallback                          | Why |
+|-----------------------|------------------------------------------|-----------------------------------|-----|
+| `leviathan-abyssal`   | Nano Banana Pro (`nano-banana-pro`)       | gpt-image-2 → Higgsfield          | Lore-accurate scale + atmospheric depth; grounding keeps the abyss coherent. Higgsfield for the moving world-boss shot. |
+| `godbeast-divine`     | Nano Banana Pro (`nano-banana-pro`)       | gpt-image-2 → Grok Imagine        | Radiant divine light renders best with grounded fidelity; Grok for fast variant sweeps. |
+| `guardian-portrait`   | Nano Banana Pro (`nano-banana-pro`)       | gpt-image-2 → Higgsfield          | Character fidelity + legible Guardian/Gate detail; search-grounded for canon accuracy. |
+| `luminor-card`        | Codex gpt-image-2 (`gpt-image-2`)         | Nano Banana Pro → Grok Imagine    | Clean controlled single render with deliberate name-plate negative space. |
+| `nft-1of1`            | Codex gpt-image-2 (`gpt-image-2`)         | Nano Banana Pro → Higgsfield      | Gallery-grade controllable single mint; one careful render over volume. |
+
+**Ideation across all lanes:** start in Grok Imagine (`grok-imagine`) for cheap variation sweeps,
+then promote the winning seed to the lane's primary harness for the final render.
+
+---
+
+## Anti-patterns (never)
+
+- Recenter Arcanea image-gen on one vendor — the lanes + routing table + council gate are the moat.
+- Mix lanes on one asset.
+- Batch-generate before the council approves the organic-first single.
+- Reach for paid Higgsfield for a still when a native subscription engine can do it.
+- Claim a render is "on brand" without checking it against the chosen lane's `qualityBar`.

--- a/.arcanea/gen/lanes.ts
+++ b/.arcanea/gen/lanes.ts
@@ -11,6 +11,9 @@
 // Standalone-typed: NO external imports (this file lives outside the app graph).
 //
 // Arcanea design tokens: Atlantean Teal #00bcd4 · Cosmic Blue #0d47a1 · Gold #ffd700 · ground #09090b.
+// Note on teal: #00bcd4 is the live app design-system primary (@arcanea/design-system v0.2.0+);
+// #7fffd4 is the traditional OSS/mythic palette reference in older design docs. Both are intentional
+// for their respective contexts — gen lanes use the app token so generated assets match the live UI.
 
 export type LaneId =
   | 'leviathan-abyssal'
@@ -183,5 +186,5 @@ export function getLane(id: LaneId): AestheticLane | undefined {
   return LANES[id]
 }
 
-/** The default lane when none is specified — abyssal leviathans are the flagship. */
+/** Default lane — Nethyssa's abyssal lane is the flagship asset type for Arcanea. */
 export const DEFAULT_LANE: LaneId = 'leviathan-abyssal'

--- a/.arcanea/gen/lanes.ts
+++ b/.arcanea/gen/lanes.ts
@@ -1,0 +1,187 @@
+// Arcanea Aesthetic Lanes — the multi-lane taste substrate for image generation.
+//
+// Mirrors FrankX's lib/gen/lanes.ts shape, tuned to Arcanea canon. Each lane is a
+// first-class, fully-specified art direction: palette, references, prompt fragments,
+// a compiled negative prompt, a ranked backend list, and a per-lane quality bar.
+//
+// One lane per asset. The council gate reads the CHOSEN lane and holds output against
+// THAT lane's bar — not one global standard. A leviathan-abyssal world-boss and a
+// guardian-portrait are both "on brand" because the brand is "premium, on the chosen lane."
+//
+// Standalone-typed: NO external imports (this file lives outside the app graph).
+//
+// Arcanea design tokens: Atlantean Teal #00bcd4 · Cosmic Blue #0d47a1 · Gold #ffd700 · ground #09090b.
+
+export type LaneId =
+  | 'leviathan-abyssal'
+  | 'godbeast-divine'
+  | 'guardian-portrait'
+  | 'luminor-card'
+  | 'nft-1of1'
+
+/** Backend ids the router can rank. Mirrors the harnesses in HARNESS_ROUTING.md. */
+export type BackendId =
+  | 'grok-imagine'
+  | 'gpt-image-2'
+  | 'nano-banana-pro'
+  | 'nano-banana-2'
+  | 'higgsfield'
+
+export interface AestheticLane {
+  id: LaneId
+  /** Human-readable label. */
+  label: string
+  /** Hex palette in priority order — the colors this lane is built on. */
+  palette: string[]
+  /** One sentence: the reference mood / taste lineage to calibrate against. */
+  referenceMood: string
+  /** Positive style tokens appended to every resolved prompt on this lane. */
+  promptFragments: string[]
+  /** The compiled negative prompt — what this lane refuses to render. */
+  negativePrompt: string
+  /** Backend ids that render this lane best, in rank order (primary first). */
+  bestBackends: BackendId[]
+  /** The gate checklist for THIS lane. Every item must pass before publish. */
+  qualityBar: string[]
+}
+
+export const LANES: Record<LaneId, AestheticLane> = {
+  'leviathan-abyssal': {
+    id: 'leviathan-abyssal',
+    label: 'Leviathan / Abyssal',
+    palette: ['#09090b', '#020308', '#00bcd4', '#0d47a1', '#1a2740'],
+    referenceMood:
+      'Sublime oceanic dread — a planet-scale abyssal kraken in the Sunless Fathom, obsidian hide drinking light, void-ink veins glowing through black water. Ancient, dreaming, vast beyond comprehension.',
+    promptFragments: [
+      'colossal abyssal leviathan, planet-scale kraken, obsidian hide that drinks light',
+      'bioluminescent void-ink veins glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1',
+      'eyes like drowned moons, nine primary arms, countless writhing tendrils',
+      'sunless deep-ocean abyss, near-black #09090b water, volumetric god-rays from far above',
+      'sublime cosmic horror scale, atmospheric haze, suspended marine particulate, painterly cinematic',
+      'element Water and Void, ancient and dreaming, oceanic dread',
+    ],
+    negativePrompt:
+      'bright daylight, warm tones, cartoon, cute, friendly, plastic, low detail, flat lighting, oversaturated neon, clutter, watermark, signature, text artifacts, jpeg artifacts, small scale, land setting, fish-tank, googly eyes, extra malformed limbs',
+    bestBackends: ['nano-banana-pro', 'gpt-image-2', 'higgsfield', 'grok-imagine'],
+    qualityBar: [
+      'Reads as planet-scale — scale cues (tiny ships/figures, dwarfed cities) present',
+      'Hide is obsidian and light-drinking, never glossy plastic',
+      'Glow comes only from void-ink veins in cyan-teal / cosmic-blue, on near-black water',
+      'Mood is sublime dread, not monster-of-the-week kitsch',
+      'Anatomy is coherent — nine primary arms read, tendrils not malformed',
+      'Water has depth, haze, and particulate — never a flat backdrop',
+    ],
+  },
+
+  'godbeast-divine': {
+    id: 'godbeast-divine',
+    label: 'Godbeast / Divine',
+    palette: ['#09090b', '#ffd700', '#00bcd4', '#0d47a1', '#fff4cf'],
+    referenceMood:
+      'A radiant divine beast bonded to a Gate — luminous, mythic, awe-commanding. Light as the subject, gold and teal energy, the register of the Ten Godbeasts.',
+    promptFragments: [
+      'radiant divine godbeast, mythic guardian-creature, awe-commanding presence',
+      'luminous golden #ffd700 energy with Atlantean-teal #00bcd4 and cosmic-blue #0d47a1 accents',
+      'volumetric light radiating from the creature, sacred geometry haze, motivated rim light',
+      'near-black #09090b stage, painterly photoreal, fine detail in scale/feather/hide texture',
+      'epic mythological composition, single hero subject, cinematic depth',
+    ],
+    negativePrompt:
+      'mundane animal, cartoon, plastic toy, flat lighting, dull, desaturated, cluttered background, stock photo, watermark, signature, text, malformed anatomy, extra limbs, lowres, jpeg artifacts, oversaturated rainbow',
+    bestBackends: ['nano-banana-pro', 'gpt-image-2', 'grok-imagine', 'higgsfield'],
+    qualityBar: [
+      'Light is the subject — the beast radiates, not a flat overlay',
+      'Gold/teal energy holds; no rainbow oversaturation',
+      'A single, nameable hero creature on a dark stage',
+      'Texture (scale/feather/hide) is detailed and coherent',
+      'Reads as divine and mythic, not a zoo animal',
+      'Anatomy is clean — no malformed or extra limbs',
+    ],
+  },
+
+  'guardian-portrait': {
+    id: 'guardian-portrait',
+    label: 'Guardian Portrait',
+    palette: ['#09090b', '#00bcd4', '#0d47a1', '#ffd700', '#e8eef5'],
+    referenceMood:
+      'One of the Ten Guardians — painterly photoreal character portrait. Dignified, elemental, the v3 hero register: ultra-quality, motivated light, gate-frequency energy.',
+    promptFragments: [
+      'painterly photorealistic character portrait, one of the Ten Guardians of Arcanea',
+      'dignified mythic figure, elemental aura, gate-frequency energy in Atlantean-teal #00bcd4',
+      'cosmic-blue #0d47a1 depth, gold #ffd700 accents, near-black #09090b background',
+      'motivated key light from upper-left, cool rim light, soft ambient bounce',
+      'ultra-quality detail in face/eyes/garment, shallow depth of field, hero composition',
+    ],
+    negativePrompt:
+      'cartoon, anime waifu, 3d render look, plastic skin, oversharpened, flat lighting, generic fantasy stock, watermark, signature, text, extra fingers, malformed hands, asymmetric eyes, lowres, jpeg artifacts, busy background',
+    bestBackends: ['nano-banana-pro', 'gpt-image-2', 'higgsfield', 'grok-imagine'],
+    qualityBar: [
+      'Face and eyes are coherent, ultra-quality, no anatomy errors',
+      'Light is motivated and dimensional, never flat',
+      'Elemental aura reads in teal/blue/gold, not generic glow',
+      'Background is dark and uncluttered — the figure is the subject',
+      'Skin and garment read painterly-photoreal, not plastic 3D',
+      'Dignified mythic presence, not generic fantasy-stock',
+    ],
+  },
+
+  'luminor-card': {
+    id: 'luminor-card',
+    label: 'Luminor Collectible Card',
+    palette: ['#09090b', '#00bcd4', '#ffd700', '#0d47a1', '#12151c'],
+    referenceMood:
+      'A collectible trading-card aesthetic — framed character art with a clear focal subject, premium card-game finish, room for a name plate and frame treatment.',
+    promptFragments: [
+      'premium collectible trading-card character art, centered framed subject',
+      'card-game finish, clean focal composition, decorative gold #ffd700 frame energy',
+      'Atlantean-teal #00bcd4 and cosmic-blue #0d47a1 rarity glow, near-black #09090b ground',
+      'crisp foreground subject with negative space for a name plate, balanced card layout',
+      'illustrative-photoreal, rich detail, premium print quality',
+    ],
+    negativePrompt:
+      'cluttered, busy edges, off-center subject, flat lighting, muddy colors, low detail, cheap clipart, watermark, random text, jpeg artifacts, lowres, malformed anatomy, cropped subject',
+    bestBackends: ['gpt-image-2', 'nano-banana-pro', 'grok-imagine', 'higgsfield'],
+    qualityBar: [
+      'Subject is centered with deliberate negative space for a name plate',
+      'Frame/rarity glow reads in gold + teal, premium card-game finish',
+      'Single clear focal subject, never cropped at the edges',
+      'Colors are rich and clean, not muddy',
+      'Composition is balanced and print-ready',
+      'No stray text or clipart artifacts',
+    ],
+  },
+
+  'nft-1of1': {
+    id: 'nft-1of1',
+    label: 'NFT 1/1 Premium',
+    palette: ['#09090b', '#00bcd4', '#0d47a1', '#ffd700', '#05070d'],
+    referenceMood:
+      'A premium one-of-one collectible — gallery-grade, museum-lit, unmistakably scarce. Maximum craft and detail, a piece that justifies a 1/1 mint.',
+    promptFragments: [
+      'museum-grade one-of-one collectible artwork, gallery-lit, unmistakably premium',
+      'maximum craft and fine detail, intricate texture, signature centerpiece subject',
+      'Atlantean-teal #00bcd4 and cosmic-blue #0d47a1 energy, gold #ffd700 highlights, deep #09090b ground',
+      'dramatic motivated lighting, cinematic depth, flawless rendering, scarce and iconic',
+      'high-resolution, collectible-poster framing, refined color grade',
+    ],
+    negativePrompt:
+      'cheap, generic, mass-produced look, flat lighting, low detail, blurry, plastic, oversaturated, clutter, stock photo, watermark, signature, random text, jpeg artifacts, lowres, malformed anatomy, banding',
+    bestBackends: ['gpt-image-2', 'nano-banana-pro', 'higgsfield', 'grok-imagine'],
+    qualityBar: [
+      'Detail and craft are maximal — this could hang in a gallery',
+      'Lighting is dramatic and motivated, never flat',
+      'A single iconic centerpiece subject worth a 1/1 mint',
+      'Color grade is refined — teal/blue/gold on deep black, no banding',
+      'Rendering is flawless, high-resolution, no artifacts',
+      'Feels scarce and premium, never mass-produced',
+    ],
+  },
+}
+
+/** Resolve a lane by id, or undefined if unknown. */
+export function getLane(id: LaneId): AestheticLane | undefined {
+  return LANES[id]
+}
+
+/** The default lane when none is specified — abyssal leviathans are the flagship. */
+export const DEFAULT_LANE: LaneId = 'leviathan-abyssal'

--- a/.arcanea/gen/prompt-packs/atlas-sky-wanderer.md
+++ b/.arcanea/gen/prompt-packs/atlas-sky-wanderer.md
@@ -1,0 +1,83 @@
+---
+subject: sky-wanderer
+subject_type: arcanea_variant
+source_universe: avatar-the-last-airbender
+source_creature: sky-bison
+promotable: true
+lane: leviathan-abyssal
+---
+
+# The Sky Wanderer — Arcanea Variant Prompt Pack
+
+**IP note**: These prompts describe the ARCANEA-ORIGINAL creature only. No Avatar-style
+visuals, no arrow markings, no bison silhouette. The Sky Wanderer is a cloud-glass
+cetacean with a star-map underbelly — entirely distinct from any source IP.
+
+---
+
+## Hero (Wide) — Grok Imagine (TUI: /imagine)
+
+**Positive**:
+A colossal six-winged cloud whale soaring above mountain peaks, body translucent as
+spun crystal glass, silver-white bioluminescent star-map patterns trace its wings,
+the underside of its body glows with shifting blue-white constellations, one tiny human
+figure stands on its back for scale, upper atmosphere cloudscape, golden-hour light
+refracting through its crystalline form, epic cosmic fantasy painting, dramatic upward
+perspective, Arcanea universe
+
+**Negative**:
+cartoon, anime, flying bison, arrow markings, horns, Earth-tone brown, thick fur,
+four-legged beast, plain white
+
+---
+
+## Hero (Wide) — Codex gpt-image-2 (ChatGPT: $imagegen)
+
+**Note**: Prefix with `$imagegen` in ChatGPT Pro
+
+**Positive**:
+Enormous translucent whale with six segmented crystalline wings, body made of compressed
+cloud-glass showing internal light, silver-white bioluminescent star-constellation patterns
+on its underbelly, soaring through a sunrise upper atmosphere, tiny mountain peaks far below,
+dramatic scale contrast, cosmic fantasy concept art, high detail, photorealistic lighting
+
+**Negative**:
+cartoon, simple, bison, horns, brown fur, anime-style
+
+---
+
+## Full Body (Creature Sheet) — Antigravity NB2
+
+**Note**: NB2 excels at search-grounded, text-legible detailed anatomy sheets.
+
+**Positive**:
+Creature concept reference sheet: The Sky Wanderer. Six-winged cloud-whale, 80m wingspan.
+Translucent body like spun ice, internal star-map patterns visible through skin, each wing
+segmented like a manta ray but crystalline and faceted, underbelly emits shifting blue-silver
+light. Scale reference: human figure (2m) beside the creature's left wing root. Clean white
+background, turnaround view, technical fantasy illustration style. Labels: Wing joint,
+Star-map skin, Cloud-glass hull, Frequency antenna (a horn-like protrusion vibrating at Gate Hz)
+
+**Negative**:
+flat, simple, low detail, bison-like, Earth tones, cartoon
+
+---
+
+## NFT 1/1 — Codex gpt-image-2 ($imagegen)
+
+**Positive**:
+Ultra-premium collector piece: The Sky Wanderer spirit-whale descending through twilight
+clouds, crystalline form catching the last sunlight and splitting it into prismatic cloud-bows,
+a single golden point of light where its eye rests, rich deep indigo and cold gold palette,
+vertical portrait format 2:3, jewellery-quality digital art, collector piece aesthetic,
+Arcanea universe
+
+**Negative**:
+generic, busy background, cartoon, simple, horizontal format
+
+---
+
+## Output Paths (DAM convention)
+- Hero: `public/leviathans/sky-wanderer-hero.png`
+- Full body: `public/leviathans/sky-wanderer-full.png`
+- NFT: `public/leviathans/sky-wanderer-nft.png`

--- a/.arcanea/gen/prompt-packs/atlas-titan-shell.md
+++ b/.arcanea/gen/prompt-packs/atlas-titan-shell.md
@@ -1,0 +1,76 @@
+---
+subject: titan-shell
+subject_type: arcanea_variant
+source_universe: avatar-the-last-airbender
+source_creature: lion-turtle
+promotable: true
+lane: godbeast-divine
+---
+
+# The Titan Shell — Arcanea Variant Prompt Pack
+
+**IP note**: Arcanea-original design: ancient script on shell, mountain-peak dorsal growths,
+supernova-glow eyes. No visual resemblance to source IP required or desired.
+
+---
+
+## Hero (Wide) — Grok Imagine
+
+**Positive**:
+An impossibly vast ancient stone turtle, its shell the size of a mountain range with actual
+peaks growing from it, ancient glowing Arcanea script carved across every surface catching
+the light of a dying sun, supernova eyes slowly illuminating an ocean of clouds far below,
+deep space visible at the edge of frame, cosmic scale, photorealistic fantasy epic, low angle
+looking up from ocean surface, Arcanea universe
+
+**Negative**:
+small, lion-turtle, lion face, friendly, cartoony, simple, anime
+
+---
+
+## Hero (Wide) — Codex gpt-image-2 ($imagegen)
+
+**Positive**:
+A continent-scale ancient stone turtle covered in glowing inscription-script, entire mountain
+ranges jutting from its shell, deep-sea phosphorescent light glowing from cracks in its shell
+plates, twin supernova eyes burning cold white, seen from the perspective of an ocean ship
+dwarfed to insignificance, cosmic fantasy epic painting, photorealistic lighting, deep atmosphere
+
+**Negative**:
+small, cartoonish, friendly, lion-face, simple
+
+---
+
+## Full Body (Creature Sheet) — Antigravity NB2
+
+**Positive**:
+Creature concept reference sheet: The Titan Shell. A continent-scale turtle (100km shell
+length). Shell surface covered in carved Arcanea script that glows amber. Three mountain-peak
+formations rise from the dorsal shell like broken teeth. Ancient cities in ruins visible along
+the shell ridgeline. Scale reference: a merchant ship (60m) visible at lower-left corner.
+Eyes glow like white supernovae. Clean dark-navy background. Technical fantasy illustration.
+Labels: Shell Script Layer, Mountain Spines, Ancient City Ruins, Foundation Crack (glowing),
+Supernova Eye.
+
+**Negative**:
+small, cartoonish, simple, white background, bright colors
+
+---
+
+## NFT 1/1 — Codex gpt-image-2 ($imagegen)
+
+**Positive**:
+Ultra-premium digital collectible: The Titan Shell rising from a primordial ocean at cosmic
+scale, a full moon behind its shell creates a halo eclipse effect, the inscriptions on its
+shell glow amber against the deep navy sky, towering isolated composition, godlike presence,
+dark luxury collector aesthetic, vertical portrait, Arcanea universe
+
+**Negative**:
+cartoon, bright colors, small scale, busy foreground
+
+---
+
+## Output Paths (DAM convention)
+- Hero: `public/leviathans/titan-shell-hero.png`
+- Full body: `public/leviathans/titan-shell-full.png`
+- NFT: `public/leviathans/titan-shell-nft.png`

--- a/.arcanea/gen/prompt-packs/nethyssa.md
+++ b/.arcanea/gen/prompt-packs/nethyssa.md
@@ -1,0 +1,102 @@
+# Nethyssa — Image Prompt-Pack
+
+> The Drowned Deep made visible. Nethyssa is a planet-scale abyssal leviathan of the
+> Sunless Fathom — obsidian hide that drinks light, void-ink veins glowing cyan-teal
+> (#00bcd4) and cosmic-blue (#0d47a1), eyes like drowned moons, nine primary arms and
+> countless tendrils, sunken dead cities carried on her back. Element: Water + Void.
+> Mood: sublime, ancient, dreaming, oceanic dread.
+>
+> **Outputs land in `/leviathans/`** following the registry convention
+> `/leviathans/<name>-<variant>.webp`. Register every render via the DAM.
+>
+> Usage: pick the variant, paste the POSITIVE + NEGATIVE into the recommended harness
+> (see `../HARNESS_ROUTING.md`), hold the lane's `qualityBar` (see `../lanes.ts`).
+> One lane per asset. Council-gate the organic-first single before any batch.
+
+---
+
+## (a) Hero portrait
+- **Lane:** `leviathan-abyssal` · **Harness:** Nano Banana Pro (search-grounded) · **Output:** `/leviathans/nethyssa-hero.webp`
+
+**POSITIVE:**
+Nethyssa, planet-scale abyssal leviathan kraken, monumental head-and-shoulders hero portrait rising from the Sunless Fathom. Obsidian hide that drinks light, near-black #09090b surface with no specular sheen. Bioluminescent void-ink veins tracing the hide, glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1 from within. Two enormous eyes like drowned moons — pale, luminous, ancient. Nine primary arms beginning to spread, countless finer tendrils drifting. Sunless deep-ocean abyss, volumetric god-rays falling from far above, suspended marine particulate, atmospheric haze. Sublime cosmic-horror scale, painterly cinematic, ancient and dreaming, oceanic dread. Element Water and Void.
+
+**NEGATIVE:**
+bright daylight, warm tones, cartoon, cute, friendly, glossy plastic, flat lighting, oversaturated neon, clutter, watermark, signature, text artifacts, jpeg artifacts, small scale, land setting, googly eyes, malformed extra limbs, lowres
+
+---
+
+## (b) Full-body abyssal establishing shot
+- **Lane:** `leviathan-abyssal` · **Harness:** Nano Banana Pro · **Output:** `/leviathans/nethyssa-fullbody.webp`
+
+**POSITIVE:**
+Full-body establishing shot of Nethyssa, planet-scale abyssal kraken suspended in the Sunless Fathom. Entire colossal form visible — obsidian light-drinking hide, nine primary arms and countless writhing tendrils filling the deep. Bioluminescent void-ink veins glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1 across the whole body. Eyes like drowned moons. Sunken dead cities clustered on her vast back, drowned spires and broken towers. Near-black #09090b abyssal water, faint god-rays from an unreachable surface, heavy particulate, volumetric haze. Sublime oceanic dread, immense scale, painterly cinematic wide composition. Element Water and Void.
+
+**NEGATIVE:**
+bright, daylight, warm, cartoon, plastic, flat lighting, neon oversaturation, clutter, watermark, signature, text, jpeg artifacts, cropped body, land, fish-tank, malformed limbs, lowres
+
+---
+
+## (c) World-boss encounter (scale)
+- **Lane:** `leviathan-abyssal` · **Harness:** Nano Banana Pro → Higgsfield (for motion) · **Output:** `/leviathans/nethyssa-worldboss.webp`
+
+**POSITIVE:**
+World-boss encounter — Nethyssa, planet-scale abyssal leviathan, dwarfing tiny ships and minuscule figures for overwhelming scale. The kraken's obsidian bulk fills the frame while a fleet of small vessels and lone divers are specks against her nine rising arms. Void-ink veins blaze cyan-teal #00bcd4 and cosmic-blue #0d47a1 through the black water. Eyes like drowned moons turning toward the intruders. Sunken dead cities on her back. Near-black #09090b deep ocean, god-rays from far above, churning particulate, atmospheric haze. Sublime cosmic dread, epic cinematic scale, painterly. Element Water and Void.
+
+**NEGATIVE:**
+no sense of scale, equal-sized ships, bright daylight, warm tones, cartoon, plastic, flat lighting, oversaturated neon, watermark, signature, text, jpeg artifacts, land setting, malformed limbs, lowres
+
+---
+
+## (d) NFT 1/1
+- **Lane:** `nft-1of1` · **Harness:** Codex gpt-image-2 · **Output:** `/leviathans/nethyssa-nft-1of1.webp`
+
+**POSITIVE:**
+Museum-grade one-of-one collectible of Nethyssa, the abyssal leviathan of the Drowned Deep. Gallery-lit, unmistakably premium, maximum craft and intricate detail. Iconic centerpiece composition — her obsidian light-drinking hide and drowned-moon eyes, void-ink veins glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1, gold #ffd700 highlights catching the finest edges. Deep #09090b ground, dramatic motivated lighting, cinematic depth, refined color grade, flawless high-resolution rendering. Scarce and iconic, worthy of a 1/1 mint. Element Water and Void.
+
+**NEGATIVE:**
+cheap, generic, mass-produced, flat lighting, low detail, blurry, plastic, oversaturated, clutter, stock photo, watermark, signature, random text, jpeg artifacts, banding, malformed anatomy, lowres
+
+---
+
+## (e) Krakenling (brood)
+- **Lane:** `leviathan-abyssal` · **Harness:** Grok Imagine (ideation) → Nano Banana Pro · **Output:** `/leviathans/nethyssa-krakenling.webp`
+
+**POSITIVE:**
+A Krakenling — juvenile spawn of Nethyssa, a small abyssal kraken in the Sunless Fathom. Obsidian light-drinking hide, void-ink veins glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1, smaller drowned-moon eyes, nimble arms and trailing tendrils. Near-black #09090b deep water, faint god-rays, suspended particulate, volumetric haze. Menacing yet diminutive, the brood of the Drowned Deep, painterly cinematic, oceanic dread. Element Water and Void.
+
+**NEGATIVE:**
+cute, cartoon, friendly mascot, bright, daylight, warm tones, plastic, flat lighting, oversaturated neon, clutter, watermark, signature, text, jpeg artifacts, land, fish-tank, malformed limbs, lowres
+
+---
+
+## (f) Abyssal Tendril (brood)
+- **Lane:** `leviathan-abyssal` · **Harness:** Grok Imagine (ideation) → Nano Banana Pro · **Output:** `/leviathans/nethyssa-abyssal-tendril.webp`
+
+**POSITIVE:**
+An Abyssal Tendril — a single severed-seeming, autonomous limb of the Drowned Deep, immense and serpentine in the Sunless Fathom. Obsidian light-drinking surface, void-ink veins pulsing cyan-teal #00bcd4 and cosmic-blue #0d47a1 along its length, lined with grasping suckers. Coiling through near-black #09090b abyssal water, god-rays from far above, heavy particulate, atmospheric haze. Sublime oceanic dread, painterly cinematic, ancient and dreaming. Element Water and Void.
+
+**NEGATIVE:**
+bright, daylight, warm tones, cartoon, plastic, flat lighting, oversaturated neon, clutter, watermark, signature, text, jpeg artifacts, land, malformed, lowres, full kraken body
+
+---
+
+## (g) Drowned Herald (brood)
+- **Lane:** `leviathan-abyssal` · **Harness:** Nano Banana Pro (search-grounded) · **Output:** `/leviathans/nethyssa-drowned-herald.webp`
+
+**POSITIVE:**
+A Drowned Herald — a once-human servant of Nethyssa, drowned and reborn as her emissary in the Sunless Fathom. Pale corpse-light skin laced with void-ink veins glowing cyan-teal #00bcd4 and cosmic-blue #0d47a1, drowned-moon eyes, tattered deep-sea regalia fused with obsidian growth and nacre. Suspended in near-black #09090b abyssal water, god-rays from far above, particulate, volumetric haze. Solemn, eerie, devotional, painterly cinematic, oceanic dread. Element Water and Void.
+
+**NEGATIVE:**
+healthy living person, bright, daylight, warm tones, cartoon, plastic skin, flat lighting, oversaturated neon, clutter, watermark, signature, text, extra fingers, malformed hands, asymmetric eyes, jpeg artifacts, land, lowres
+
+---
+
+## (h) The Nethyss Pearl (item / material card)
+- **Lane:** `luminor-card` · **Harness:** Codex gpt-image-2 · **Output:** `/leviathans/nethyss-pearl-item.webp`
+
+**POSITIVE:**
+Premium collectible item card of the Nethyss Pearl — luminous abyssal nacre formed in the heart of the Drowned Deep. A single centered orb of deep iridescent pearl, its surface swirling obsidian-black shot through with bioluminescent cyan-teal #00bcd4 and cosmic-blue #0d47a1 light, gold #ffd700 frame energy at the card edges. Floating on a near-black #09090b ground with deliberate negative space for a name plate. Crisp focal subject, rarity glow, premium card-game finish, balanced print-ready layout, illustrative-photoreal, rich detail. Element Water and Void.
+
+**NEGATIVE:**
+cluttered, busy edges, off-center, flat lighting, muddy colors, low detail, cheap clipart, watermark, random text, jpeg artifacts, lowres, cropped subject, plastic bead, oversaturated rainbow

--- a/.arcanea/intake/canon-spectrum.ts
+++ b/.arcanea/intake/canon-spectrum.ts
@@ -1,0 +1,103 @@
+// Arcanea Hermes — the canon ↔ tech fit axis + canon-tier guesser.
+//
+// Two questions decide how a capture is handled:
+//   1. Where does it sit on the canon ↔ tech spectrum? (does it touch the
+//      living mythology, or is it a tech/mechanics artifact, or a blend?)
+//   2. If it carries a new entity, where does it sit on the Monster System
+//      ladder (T0–T4), and does that require a canon gate before it ships?
+//
+// New named entities at the Wild-Godbeast (T3) or Gate-Godbeast (T4) tier ALWAYS
+// require the canon gate — they touch the locked mythology and can never
+// auto-land. See `.arcanea/lore/creatures/MONSTER_SYSTEM.md` (T4 LOCKED, T3 OPEN
+// but Creator-approval-gated) and `CANON_LOCKED.md`.
+//
+// Standalone + typed — no external imports (`.arcanea/` is a tool-agnostic
+// config dir, not part of a tsconfig build).
+
+import type { CanonTier } from './capture-types'
+
+export type Spectrum = 'canon' | 'mixed' | 'tech'
+
+/**
+ * Signals Hermes extracts from a capture during the intake pass. All optional —
+ * the classifier fills what it can read; absent signals are treated as unknown,
+ * which biases the result toward the safe (gated) side.
+ */
+export interface CanonSignals {
+  /** capture introduces a brand-new named entity (creature, character, place, artifact) */
+  introducesNewEntity?: boolean
+  /** references existing locked canon (a God, Godbeast, Gate, the Arc, Malachar) */
+  referencesLockedCanon?: boolean
+  /** scale of the entity, if it is a creature — maps to the Monster ladder */
+  creatureScale?: 'mote' | 'beast' | 'shade' | 'leviathan' | 'godbeast'
+  /** entity is/was bonded to a God — only the Ten Gate Godbeasts are bonded (T4) */
+  bonded?: boolean
+  /** capture is primarily mechanics / code / platform, not mythology */
+  techLeaning?: boolean
+}
+
+export interface CanonFit {
+  spectrum: Spectrum
+  canonTier: CanonTier
+  /** true → cannot ship without the canon gate (arcanea-canon + Frank lock-decision) */
+  requiresCanonGate: boolean
+}
+
+const SCALE_TO_TIER: Record<NonNullable<CanonSignals['creatureScale']>, CanonTier> = {
+  mote: 'T0',
+  beast: 'T1',
+  shade: 'T2',
+  leviathan: 'T3',
+  godbeast: 'T4',
+}
+
+/**
+ * Classify a capture's canon fit from extracted signals.
+ *
+ * Tier logic (Monster System):
+ *   - explicit creatureScale wins (mote→T0 … godbeast→T4)
+ *   - bonded entity with no scale → T4 (only the Ten are bonded)
+ *   - a new entity with no scale/bond signal → T3 (unbonded Wild Godbeast prior;
+ *     the conservative default, because it forces the gate)
+ *   - no new entity → 'none'
+ *
+ * Gate logic: any T3/T4 entity ALWAYS requires the gate. A new entity that
+ * references locked canon also requires it (it can contradict the mythology).
+ */
+export function classifyCanonFit(signals: CanonSignals): CanonFit {
+  const {
+    introducesNewEntity = false,
+    referencesLockedCanon = false,
+    creatureScale,
+    bonded = false,
+    techLeaning = false,
+  } = signals
+
+  // --- spectrum ---
+  let spectrum: Spectrum
+  if (techLeaning && !referencesLockedCanon && !introducesNewEntity) {
+    spectrum = 'tech'
+  } else if (referencesLockedCanon || introducesNewEntity) {
+    spectrum = techLeaning ? 'mixed' : 'canon'
+  } else {
+    spectrum = 'mixed'
+  }
+
+  // --- canon tier ---
+  let canonTier: CanonTier
+  if (creatureScale) {
+    canonTier = SCALE_TO_TIER[creatureScale]
+  } else if (bonded) {
+    canonTier = 'T4'
+  } else if (introducesNewEntity) {
+    canonTier = 'T3' // conservative: unbonded new entity forces the gate
+  } else {
+    canonTier = 'none'
+  }
+
+  // --- gate ---
+  const newEntityTier = canonTier === 'T3' || canonTier === 'T4'
+  const requiresCanonGate = newEntityTier || (introducesNewEntity && referencesLockedCanon)
+
+  return { spectrum, canonTier, requiresCanonGate }
+}

--- a/.arcanea/intake/canon-spectrum.ts
+++ b/.arcanea/intake/canon-spectrum.ts
@@ -11,8 +11,8 @@
 // auto-land. See `.arcanea/lore/creatures/MONSTER_SYSTEM.md` (T4 LOCKED, T3 OPEN
 // but Creator-approval-gated) and `CANON_LOCKED.md`.
 //
-// Standalone + typed — no external imports (`.arcanea/` is a tool-agnostic
-// config dir, not part of a tsconfig build).
+// Standalone + typed — no external package imports (only intra-dir `import
+// type`; `.arcanea/` is a tool-agnostic config dir, not part of a tsconfig build).
 
 import type { CanonTier } from './capture-types'
 

--- a/.arcanea/intake/capture-types.ts
+++ b/.arcanea/intake/capture-types.ts
@@ -114,7 +114,8 @@ export function getCaptureType(id: CaptureType): CaptureTypeMeta {
  */
 export function inferCaptureType(mimeType: string, extension: string): CaptureTypeMeta | undefined {
   const lowerExt = extension.toLowerCase()
-  const byExt = CAPTURE_TYPE_LIST.find((c) => c.extensions.includes(lowerExt))
+  const normalizedExt = lowerExt.startsWith('.') ? lowerExt : `.${lowerExt}`
+  const byExt = CAPTURE_TYPE_LIST.find((c) => c.extensions.includes(normalizedExt))
   if (byExt) return byExt
   return CAPTURE_TYPE_LIST.find((c) => c.mimeTypes.includes(mimeType))
 }

--- a/.arcanea/intake/capture-types.ts
+++ b/.arcanea/intake/capture-types.ts
@@ -1,0 +1,120 @@
+// Arcanea Hermes — capture-type substrate.
+//
+// Every inbound creative capture maps to exactly one CaptureType. The Hermes
+// intake phase reads mime + extension to infer the type; when ambiguous, a
+// multimodal pass decides. Standalone + typed — no external imports, because
+// `.arcanea/` is a tool-agnostic config dir, not part of a tsconfig build.
+//
+// `defaultCanonTier` is a *guess* at where new lore-bearing captures sit on the
+// Monster System ladder (`.arcanea/lore/creatures/MONSTER_SYSTEM.md`):
+//   T0 Motes · T1 Beasts · T2 Shades · T3 Leviathans/Wild Godbeasts · T4 Gate Godbeasts.
+// `none` = the capture carries no new canon entity by default (text, art, music).
+// The real tier is decided by canon-spectrum.ts at classify time; this is a prior.
+
+export type CaptureType =
+  | 'lore-text'
+  | 'monster-concept'
+  | 'character-sketch'
+  | 'concept-art'
+  | 'guardian-wisdom'
+  | 'music-seed'
+  | 'world-fragment'
+
+export type CanonTier = 'T0' | 'T1' | 'T2' | 'T3' | 'T4' | 'none'
+
+export interface CaptureTypeMeta {
+  id: CaptureType
+  label: string
+  description: string
+  /** mime types this capture commonly arrives as */
+  mimeTypes: string[]
+  /** lowercase file extensions (with dot) that match this capture */
+  extensions: string[]
+  /** prior guess at the Monster System tier; canon-spectrum.ts decides the real one */
+  defaultCanonTier: CanonTier
+}
+
+export const CAPTURE_TYPES: Record<CaptureType, CaptureTypeMeta> = {
+  'lore-text': {
+    id: 'lore-text',
+    label: 'Lore text',
+    description:
+      'A written lore note, myth fragment, timeline entry, or canon proposal. Prose or markdown. Source for book/ collections, CANON_LOCKED entries, world bible.',
+    mimeTypes: ['text/markdown', 'text/plain', 'application/pdf'],
+    extensions: ['.md', '.mdx', '.txt', '.pdf'],
+    defaultCanonTier: 'none',
+  },
+  'monster-concept': {
+    id: 'monster-concept',
+    label: 'Monster concept',
+    description:
+      'A creature idea — name, element(s), scale, behavior — destined for the Monster System ladder. Text brief or annotated sketch. New creatures default to the unbonded Wild-Godbeast tier until graded.',
+    mimeTypes: ['text/markdown', 'text/plain', 'image/png', 'image/jpeg', 'image/webp'],
+    extensions: ['.md', '.txt', '.png', '.jpg', '.jpeg', '.webp'],
+    defaultCanonTier: 'T3',
+  },
+  'character-sketch': {
+    id: 'character-sketch',
+    label: 'Character sketch',
+    description:
+      'A character idea or visual reference — Creator, Luminor, NPC, Academy figure. Drawing, render, or written profile. Source for character-forge + visual production.',
+    mimeTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'text/markdown', 'text/plain'],
+    extensions: ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.md', '.txt'],
+    defaultCanonTier: 'none',
+  },
+  'concept-art': {
+    id: 'concept-art',
+    label: 'Concept art',
+    description:
+      'A location, artifact, scene, or mood-board image with no single named entity attached. Environmental or atmospheric. Source for the image registry + world-builder backdrops.',
+    mimeTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/svg+xml'],
+    extensions: ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.svg'],
+    defaultCanonTier: 'none',
+  },
+  'guardian-wisdom': {
+    id: 'guardian-wisdom',
+    label: 'Guardian wisdom',
+    description:
+      'A voice memo — spoken lore, a Guardian-voiced teaching, a dictated idea, a ritual. Transcribed first, then routed. Source for book/ wisdom collections, dialogues, and prose.',
+    mimeTypes: ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/x-m4a', 'audio/ogg', 'audio/webm'],
+    extensions: ['.m4a', '.mp3', '.wav', '.ogg', '.opus', '.webm'],
+    defaultCanonTier: 'none',
+  },
+  'music-seed': {
+    id: 'music-seed',
+    label: 'Music seed',
+    description:
+      'A hummed melody, found-sound clip, loop idea, or Gate-frequency motif. Short audio. Source for Suno prompts + the soundscape pipeline (Ten Gates run 174–1111 Hz).',
+    mimeTypes: ['audio/mpeg', 'audio/mp4', 'audio/wav'],
+    extensions: ['.m4a', '.mp3', '.wav'],
+    defaultCanonTier: 'none',
+  },
+  'world-fragment': {
+    id: 'world-fragment',
+    label: 'World fragment',
+    description:
+      'A loose structured snippet — faction note, map region, item stat block, mixed-mode brain dump that spans lore + mechanics. Source for world-builder framework + Academy handbook.',
+    mimeTypes: ['text/markdown', 'text/plain', 'application/json'],
+    extensions: ['.md', '.mdx', '.txt', '.json'],
+    defaultCanonTier: 'T1',
+  },
+}
+
+/** All capture-type metas as an array (stable order). */
+export const CAPTURE_TYPE_LIST: CaptureTypeMeta[] = Object.values(CAPTURE_TYPES)
+
+export function getCaptureType(id: CaptureType): CaptureTypeMeta {
+  return CAPTURE_TYPES[id]
+}
+
+/**
+ * Infer a capture type from a file's mime + extension.
+ * Extension wins (most reliable); mime is the fallback. Returns undefined when
+ * nothing matches — the caller must surface it, never silently guess.
+ */
+export function inferCaptureType(mimeType: string, extension: string): CaptureTypeMeta | undefined {
+  const lowerExt = extension.toLowerCase()
+  const byExt = CAPTURE_TYPE_LIST.find((c) => c.extensions.includes(lowerExt))
+  if (byExt) return byExt
+  return CAPTURE_TYPE_LIST.find((c) => c.mimeTypes.includes(mimeType))
+}

--- a/.arcanea/intake/producers.ts
+++ b/.arcanea/intake/producers.ts
@@ -4,7 +4,8 @@
 // canon-spectrum) and fans one classified capture into per-surface output. This
 // mirrors the FrankX L4-producer shipping pattern: add a producer in ~1 day, the
 // registry drives every downstream surface. Standalone + typed — no external
-// imports (`.arcanea/` is a tool-agnostic config dir, not part of a build).
+// package imports (only intra-dir `import type`; `.arcanea/` is a tool-agnostic
+// config dir, not part of a build).
 
 import type { CaptureType } from './capture-types'
 

--- a/.arcanea/intake/producers.ts
+++ b/.arcanea/intake/producers.ts
@@ -1,0 +1,101 @@
+// Arcanea Hermes — producer substrate.
+//
+// 5 producer specialists. Each reads the same intake substrate (capture-types +
+// canon-spectrum) and fans one classified capture into per-surface output. This
+// mirrors the FrankX L4-producer shipping pattern: add a producer in ~1 day, the
+// registry drives every downstream surface. Standalone + typed — no external
+// imports (`.arcanea/` is a tool-agnostic config dir, not part of a build).
+
+import type { CaptureType } from './capture-types'
+
+export type ProducerId =
+  | 'lore-producer'
+  | 'world-builder'
+  | 'vis-producer'
+  | 'music-producer'
+  | 'prose-producer'
+
+/** Shipping maturity of a producer. Hermes defers dispatch to `planned` ones. */
+export type ProducerStatus = 'shipped' | 'partial' | 'planned'
+
+export interface Producer {
+  id: ProducerId
+  label: string
+  description: string
+  /** which capture types this producer can consume */
+  acceptedCaptureTypes: CaptureType[]
+  /** what artifact kinds it emits */
+  outputs: string[]
+  /** where its output lands — repo paths, registries, external tools */
+  targetSurfaces: string[]
+  status: ProducerStatus
+}
+
+export const PRODUCERS: Record<ProducerId, Producer> = {
+  'lore-producer': {
+    id: 'lore-producer',
+    label: 'Lore Producer',
+    description:
+      'Lore text + voice-memo wisdom → canon-aligned lore entries, myth fragments, timeline notes. Runs the arcanea-canon gate on every entry. New named entities land as STAGING in CANON_LOCKED, never auto-locked.',
+    acceptedCaptureTypes: ['lore-text', 'guardian-wisdom', 'world-fragment'],
+    outputs: ['canon-entry', 'myth-fragment', 'timeline-note', 'staging-proposal'],
+    targetSurfaces: ['.arcanea/lore', 'book/', '.arcanea/lore/CANON_LOCKED.md (staging)'],
+    status: 'shipped',
+  },
+  'world-builder': {
+    id: 'world-builder',
+    label: 'World Builder',
+    description:
+      'Monster concepts + world fragments → Monster System ladder entries (T0–T4), faction notes, region maps, item stat blocks. Grades every new creature against the tier ladder; T3/T4 always route through the canon gate.',
+    acceptedCaptureTypes: ['monster-concept', 'world-fragment', 'lore-text'],
+    outputs: ['monster-entry', 'faction-note', 'region-map', 'stat-block'],
+    targetSurfaces: ['.arcanea/lore/creatures', '.arcanea/lore', 'book/academy-handbook'],
+    status: 'partial',
+  },
+  'vis-producer': {
+    id: 'vis-producer',
+    label: 'Visual Producer',
+    description:
+      'Concept art + character sketches → registered visual assets, character renders, world backdrops, cover frames. Composes NB2 / Higgsfield. Writes nothing to the live site — assets land in the registry for review.',
+    acceptedCaptureTypes: ['concept-art', 'character-sketch', 'monster-concept'],
+    outputs: ['character-render', 'world-backdrop', 'cover-frame', 'registry-asset'],
+    targetSurfaces: ['image registry (.arcanea/design)', 'public/images (via review)'],
+    status: 'shipped',
+  },
+  'music-producer': {
+    id: 'music-producer',
+    label: 'Music Producer',
+    description:
+      'Music seeds + Gate-frequency motifs → Suno prompts, soundscape briefs, Gate-aligned tracks (Ten Gates, 174–1111 Hz). Emits prompts + briefs only; rendering is downstream.',
+    acceptedCaptureTypes: ['music-seed', 'guardian-wisdom'],
+    outputs: ['suno-prompt', 'soundscape-brief', 'gate-motif'],
+    targetSurfaces: ['suno', '.arcanea/messaging (track briefs)'],
+    status: 'partial',
+  },
+  'prose-producer': {
+    id: 'prose-producer',
+    label: 'Prose Producer',
+    description:
+      'Lore text + transcribed wisdom → Library prose: parables, dialogues, wisdom scrolls, chronicles. Brand-voice gate (arcanea-voice) applies. Pairs tightly with lore-producer for canon-checked source.',
+    acceptedCaptureTypes: ['lore-text', 'guardian-wisdom'],
+    outputs: ['library-text', 'parable', 'dialogue', 'wisdom-scroll'],
+    targetSurfaces: ['book/', 'content/fiction'],
+    status: 'shipped',
+  },
+}
+
+/** All producers as an array (stable order). */
+export const PRODUCER_LIST: Producer[] = Object.values(PRODUCERS)
+
+export function getProducer(id: ProducerId): Producer {
+  return PRODUCERS[id]
+}
+
+export function producersByStatus(status: ProducerStatus): Producer[] {
+  return PRODUCER_LIST.filter((p) => p.status === status)
+}
+
+/** Which producers accept a given capture type — the core dispatch lookup. */
+export function producersAcceptingCaptureType(type: CaptureType): Producer[] {
+  return PRODUCER_LIST.filter((p) => p.acceptedCaptureTypes.includes(type))
+}

--- a/.arcanea/lore/CANON_LOCKED.md
+++ b/.arcanea/lore/CANON_LOCKED.md
@@ -328,6 +328,28 @@ Grounded in real meteoritics: Widmanstatten crystal patterns (million-year cooli
 
 ---
 
+## THE LEVIATHAN TIER — WILD GODBEASTS (STAGING ⏳)
+
+> *"Not every great beast knelt to a Gate. Some were already old when the Gates were young."*
+
+The Ten Gate Godbeasts (Tier 2) are **bonded** — each sworn beside an Arcanean God. But beasts of **Nero's Unformed** existed before the bonding, titan-scale and sovereign to no Gate. These are the **Leviathans**, or **Wild Godbeasts**: unbonded, region-roaming, keeping their own sub-Gate frequencies. They are the wilderness to the Gates' civilization.
+
+This tier is the apex of the **Monster System** (`.arcanea/lore/creatures/MONSTER_SYSTEM.md`), which orders all Arcanean creatures: **T0 Motes → T1 Beasts → T2 Shades → T3 Leviathans → T4 Gate Godbeasts**, with a Shadow corruption track at every tier.
+
+| Leviathan | Element | Resonance | Domain | Material | Status |
+|-----------|---------|-----------|--------|----------|--------|
+| **Nethyssa, the Abyss That Dreams** | Water + Void | Abyssal Hum (sub-Gate) | The Drowned Deep / the Sunless Fathom | Nethyss Pearl | ⏳ STAGING |
+
+**STAGING TRUTHS:**
+- Leviathans are **unbonded** — no God, no Guardian, no Gate. The locked Ten are **untouched** by this tier.
+- They are **Nero's Unformed**, not evil — power that was never given a name to obey. Each has a Shadow-corruption counterpart (Nethyssa's is **the Drowned Shadow**, an extinction-tier threat parallel to the corrupted Gate dungeons).
+- The tier is **OPEN** for future Leviathans, but each requires Creator approval — the same rule as Origin Classes.
+- **Nethyssa** is the first and flagship. She is kept *dreaming*, not slain, via the canon ritual **the Tidesong** (the faithful of Leyla/Veloura). Full profile: `.arcanea/lore/leviathans/nethyssa.md`.
+
+**Full reference**: `.arcanea/lore/leviathans/` (profiles + `nethyssa-game-design.md`), `.arcanea/lore/creatures/MONSTER_SYSTEM.md`.
+
+---
+
 ## EXTENSIBILITY PRINCIPLES (LOCKED ✅)
 
 1. **New entities must have Arcanean-quality names** (Lyssandria-tier)
@@ -362,6 +384,9 @@ Grounded in real meteoritics: Widmanstatten crystal patterns (million-year cooli
 | 2026-03-30 | Material mutations system (Harmonic, Dissonant, Gray Threshold, Resonance Bloom) | ⏳ STAGING | — |
 | 2026-03-30 | Arcanean Meteors (Vael Rain, Ember Falls, Nero Strikes, Luminarch Events) | ⏳ STAGING | — |
 | 2026-03-30 | Material-Agent architecture mapping (Shael→transparent, Veloryn→adaptive, etc.) | ⏳ STAGING | — |
+| 2026-06-22 | Monster System taxonomy (T0 Motes → T4 Gate Godbeasts + Shadow corruption track) | ⏳ STAGING | — |
+| 2026-06-22 | Leviathan tier: Wild Godbeasts (unbonded, outside the Ten Gates) | ⏳ STAGING | — |
+| 2026-06-22 | Nethyssa, the Abyss That Dreams (flagship Leviathan; Nethyss Pearl; the Drowned Shadow; the Tidesong) | ⏳ STAGING | — |
 
 ---
 

--- a/.arcanea/lore/CANON_LOCKED.md
+++ b/.arcanea/lore/CANON_LOCKED.md
@@ -332,7 +332,7 @@ Grounded in real meteoritics: Widmanstatten crystal patterns (million-year cooli
 
 > *"Not every great beast knelt to a Gate. Some were already old when the Gates were young."*
 
-The Ten Gate Godbeasts (Tier 2) are **bonded** — each sworn beside an Arcanean God. But beasts of **Nero's Unformed** existed before the bonding, titan-scale and sovereign to no Gate. These are the **Leviathans**, or **Wild Godbeasts**: unbonded, region-roaming, keeping their own sub-Gate frequencies. They are the wilderness to the Gates' civilization.
+The Ten Gate Godbeasts (T4 in the Monster System) are **bonded** — each sworn beside an Arcanean God. But beasts of **Nero's Unformed** existed before the bonding, titan-scale and sovereign to no Gate. These are the **Leviathans**, or **Wild Godbeasts**: unbonded, region-roaming, keeping their own sub-Gate frequencies. They are the wilderness to the Gates' civilization.
 
 This tier is the apex of the **Monster System** (`.arcanea/lore/creatures/MONSTER_SYSTEM.md`), which orders all Arcanean creatures: **T0 Motes → T1 Beasts → T2 Shades → T3 Leviathans → T4 Gate Godbeasts**, with a Shadow corruption track at every tier.
 

--- a/.arcanea/lore/CANON_LOCKED.md
+++ b/.arcanea/lore/CANON_LOCKED.md
@@ -342,7 +342,7 @@ This tier is the apex of the **Monster System** (`.arcanea/lore/creatures/MONSTE
 
 **STAGING TRUTHS:**
 - Leviathans are **unbonded** — no God, no Guardian, no Gate. The locked Ten are **untouched** by this tier.
-- They are **Nero's Unformed**, not evil — power that was never given a name to obey. Each has a Shadow-corruption counterpart (Nethyssa's is **the Drowned Shadow**, an extinction-tier threat parallel to the corrupted Gate dungeons).
+- They are **Nero's Unformed** — unshaped, not corrupt: power that was never given a name to obey. Each has a Shadow-corruption counterpart (Nethyssa's is **the Drowned Shadow**, an extinction-tier threat parallel to the corrupted Gate dungeons).
 - The tier is **OPEN** for future Leviathans, but each requires Creator approval — the same rule as Origin Classes.
 - **Nethyssa** is the first and flagship. She is kept *dreaming*, not slain, via the canon ritual **the Tidesong** (the faithful of Leyla/Veloura). Full profile: `.arcanea/lore/leviathans/nethyssa.md`.
 

--- a/.arcanea/lore/atlas/INDEX.md
+++ b/.arcanea/lore/atlas/INDEX.md
@@ -1,0 +1,50 @@
+---
+title: Creature Atlas Index
+status: active
+---
+
+# Creature Atlas — Index
+
+The Atlas catalogues creatures from fictional universes and the Arcanea-original
+variants they inspire.
+
+---
+
+## Catalogued Universes
+
+### Avatar: The Last Airbender ⏳ STAGING
+- **Studio**: Nickelodeon / Paramount
+- **Rights tier**: `factual_reference`
+- **Creatures**: 7 reference entries (sky-bison, lion-turtle, ancient-dragon, badgermole, flying-lemur, hei-bai, wan-shi-tong)
+- **Arcanea variants**: 3 (Sky Wanderer, Titan Shell, Sight Keeper)
+- **Data**: `packages/arcanea-mcp/src/data/atlas/universes/avatar.ts`
+
+---
+
+## Arcanea Variants (STAGING)
+
+| Variant | Source Creature | Elements | Gate | Material |
+|---|---|---|---|---|
+| The Sky Wanderer | Sky Bison | Wind, Void | — | Cloudstone |
+| The Titan Shell | Lion Turtle | Earth, Void | — | Foundation Stone |
+| The Sight Keeper | Wan Shi Tong | Void, Spirit | Sight (Lyria) | Vellum Shard |
+
+All variants require `/lock-decision` to promote from STAGING → LOCKED.
+
+---
+
+## Contribution Standard
+
+See `WORLD_REPO_STANDARD.md` for how to contribute a universe.
+
+---
+
+## Pipeline — Planned Universes
+
+Not yet contributed; queued for future Atlas work:
+
+- **Studio Ghibli** — Totoro, Soot Sprites, No-Face, Kodama (`factual_reference`)
+- **Nausicaä of the Valley of the Wind** — God Warriors, Ohm (`factual_reference`)
+- **The Elder Scrolls** — Cliff Racers, Silt Striders, Daedra (`factual_reference`)
+- **Howl's Moving Castle / Spirited Away** — Spirit variants (`factual_reference`)
+- **Marvel** — Fin Fang Foom, Flerken, Symbiotes (`factual_reference`)

--- a/.arcanea/lore/atlas/WORLD_REPO_STANDARD.md
+++ b/.arcanea/lore/atlas/WORLD_REPO_STANDARD.md
@@ -1,0 +1,97 @@
+---
+title: World Repo Standard
+version: "1.0"
+status: active
+---
+
+# World Repo Standard v1.0
+
+The Arcanea Creature Atlas is an open, curated encyclopedia of creatures from fictional
+universes — and the Arcanea-original variants they inspire.
+
+This document specifies how to contribute a universe to the Atlas.
+
+---
+
+## What the Atlas Is
+
+The Atlas has three layers for each universe:
+
+| Layer | What it is | Generates imagery? |
+|---|---|---|
+| **Reference catalog** | Factual documentation of creatures from existing IP | No |
+| **World graph** | Relationships between creatures, universes, stories | — |
+| **Arcanea variants** | Wholly original Arcanea creatures inspired by (not copied from) the reference | Yes |
+
+Arcanea variants carry no resemblance to the IP source in name, visual design, or
+generated image. They are inspired by archetype, not copied from appearance.
+
+---
+
+## Rights Tiers
+
+Every universe and creature carries a rights tier:
+
+| Tier | Meaning | Image generation |
+|---|---|---|
+| `original_arcanea` | Arcanea-native, fully owned | Freely |
+| `public_domain` | Pre-1927 or explicitly PD | With care |
+| `licensed` | CC-licensed fan use | Per license |
+| `factual_reference` | IP-protected; document only | Never for reference; yes for Arcanea variants |
+| `blocked` | IP-holder restriction | Never |
+
+Most major franchises (Avatar, Marvel, etc.) are `factual_reference`.
+
+---
+
+## How to Contribute
+
+1. **Fork** the `frankxai/arcanea` repo
+2. **Create** data files at:
+   - `packages/arcanea-mcp/src/data/atlas/universes/<universe-slug>.ts`
+   - `packages/arcanea-mcp/src/data/atlas/creatures/<universe-slug>.ts`
+   - (optional) `packages/arcanea-mcp/src/data/atlas/arcanea-variants/<universe-slug>.ts`
+3. **Follow the TypeScript interfaces** in `packages/arcanea-mcp/src/data/atlas/types.ts`
+4. **Open a PR** titled `atlas: add <Universe Name>`
+5. **Pass automated checks** (TypeScript, rights-tier validation)
+6. **Await curator review** — Frank holds merge authority
+
+---
+
+## Automated Checks
+
+Your PR will fail if:
+- Any `factual_reference` or `blocked` creature has `promptable: true`
+- A creature's `universeId` doesn't match a registered universe
+- An Arcanea variant's `sourceCreatureId` doesn't match a registered creature
+- The variant's `name` matches the source creature's `name` or `aliases[]` (no copies)
+- `schemaVersion` doesn't match current `1.0`
+- TypeScript compilation fails
+
+---
+
+## What Makes a Good Arcanea Variant
+
+A great variant:
+- Uses the source creature's **archetype** (scale, role, elemental alignment), not its visual design
+- Has an Arcanea-original name, domain, and material correspondence
+- Maps cleanly to the Arcanea Five Elements
+- Has a `materialCorrespondence` — the Vael Crystal pattern for this creature type
+- Is `canonStatus: "staging"` — only Frank's `/lock-decision` promotes to `"locked"`
+
+---
+
+## Example PR Structure
+
+```
+atlas: add Avatar: The Last Airbender
+
+universes/avatar.ts         — UniverseSpec
+creatures/avatar.ts         — 7 AtlasCreatureSpec entries (factual_reference, promptable: false)
+arcanea-variants/avatar.ts  — 3 ArcaneaVariantSpec entries (staging, original names)
+```
+
+---
+
+*Maintained by Frank Riemer (frankx.ai). Frank holds final merge authority.*
+*The Atlas is canon-additive — contributions become STAGING until promoted.*

--- a/.arcanea/lore/creatures/INDEX.md
+++ b/.arcanea/lore/creatures/INDEX.md
@@ -1,0 +1,28 @@
+---
+title: Creatures of Arcanea — Index
+status: staging
+type: index
+---
+
+# Creatures of Arcanea
+
+The living things of the universe, ordered by the **Monster System** — a single ladder running from the faintest elemental wisp to the unbonded titans of Nero's Unformed. This directory holds the framework; the tiers themselves live in their own halls.
+
+## Contents
+
+- **[The Monster System](./MONSTER_SYSTEM.md)** — the full taxonomy: the five-tier class ladder, the Corruption Track, and how to add a new monster through Hermes intake → `canon-check` → `lock-decision`.
+- **[Leviathans / Wild Godbeasts](../leviathans/INDEX.md)** — Tier 3. Titan, unbonded, region-roaming beasts of the Unformed. Home of **Nethyssa, the Abyss That Dreams**.
+
+## The Tiers at a Glance
+
+| Tier | Class | Scale | Bonded | Where it lives |
+|------|-------|-------|--------|----------------|
+| **T0** | Motes | Tiny | No | Ambient — everywhere resonance gathers |
+| **T1** | Beasts | Fauna-scaled | No | The overworld ecosystem |
+| **T2** | Shades | Mind-scaled | No | The Creator's inner path (`book/bestiary-of-creation/`) |
+| **T3** | Leviathans / Wild Godbeasts | Titan to planet | **No** | A region of the world (`lore/leviathans/`) |
+| **T4** | Gate Godbeasts | Divine | **Yes — the Ten** | The Ten Gates (`lore/godbeasts/`) — LOCKED |
+
+Running across all tiers: the **Corruption Track** — the Shadow-touched variant of any creature, Malachar's perversion of Nero's gift. Its T3 form is the **Drowned Shadow**, the nightmare Nethyssa becomes when her dream is infected.
+
+> *"Know which one you are making before you name it."*

--- a/.arcanea/lore/creatures/MONSTER_SYSTEM.md
+++ b/.arcanea/lore/creatures/MONSTER_SYSTEM.md
@@ -51,7 +51,7 @@ The existing **psychological bestiary** — the creative-block creatures of `boo
 
 ### T3 — Leviathans / Wild Godbeasts — NEW
 
-A **Wild Godbeast** is a beast of Nero's Unformed that was never bonded to a God. Where the Ten were drawn from the same primordial stock and fused to a divine partner at a Gate, the Wild Godbeasts were left in the deep places of the world — titanic, unbonded, ungated. They are not corrupt. Nero is not evil; he is the fertile unknown, and his Unformed birthed wonders the Gates never claimed. A Wild Godbeast roams a **region**, not a Gate. It carries **two elements**, and it resonates **below the audible Gate scale** — a sub-frequency hum that the Solfeggio ladder never reaches.
+A **Wild Godbeast** is a beast of Nero's Unformed that was never bonded to a God. Where the Ten were drawn from the same primordial stock and fused to a divine partner at a Gate, the Wild Godbeasts were left in the deep places of the world — titanic, unbonded, ungated. They are not corrupt. Nero is the fertile unknown, not the Shadow, and his Unformed birthed wonders the Gates never claimed. A Wild Godbeast roams a **region**, not a Gate. It carries **two elements**, and it resonates **below the audible Gate scale** — a sub-frequency hum that the Solfeggio ladder never reaches.
 
 The flagship and first of this tier is **Nethyssa, the Abyss That Dreams** — the planet-scale abyssal kraken of the Drowned Deep, dual-element Water and Void, kin-adjacent to the Flow Godbeast Veloura. Where Veloura flows, Nethyssa drowns and dreams.
 

--- a/.arcanea/lore/creatures/MONSTER_SYSTEM.md
+++ b/.arcanea/lore/creatures/MONSTER_SYSTEM.md
@@ -1,0 +1,91 @@
+---
+title: The Monster System — Arcanea's Creature Taxonomy
+status: staging
+type: system
+---
+
+# The Monster System
+
+> *"Not everything that breathes in Arcanea was given a name by a God. Some things named themselves. Some things were never meant to wake."*
+
+This is the framework that orders every living thing in Arcanea — from the faintest elemental wisp to the titans that roam outside the Ten Gates. It is **additive and reversible**: it slots new creatures into a ladder without disturbing the locked canon above it. The Ten Gate Godbeasts (Kaelith, Veloura, Draconis, Laeylinn, Otome, Yumiko, Sol, Vaelith, Kyuro, and the Source Godbeast) sit at the top, untouched. Everything new attaches below them.
+
+The ladder runs by two questions: **how large is the thing**, and **was it ever bonded to a God**. Scale climbs as you rise. Bonding only happens at the very top.
+
+---
+
+## The Class Ladder
+
+| Tier | Class | Scale | Bonding | Element behavior |
+|------|-------|-------|---------|------------------|
+| **T0** | Motes | Tiny (insect to bird) | None | Ambient — drift along resonance |
+| **T1** | Beasts | Small to large fauna | None | Single-element, attuned to a region |
+| **T2** | Shades | Symbolic / mind-scaled | None | No frequency — they feed on its absence |
+| **T3** | Leviathans / Wild Godbeasts | Titan to planet-scale | **Unbonded** | Dual-element, sub-Gate resonance |
+| **T4** | Gate Godbeasts | Continental, divine | **Bonded (the Ten)** | One Gate frequency, locked |
+
+---
+
+### T0 — Motes
+
+The smallest expression of the Five Elements: wisps, sparks, drifting embers of Fire; dewmotes and tideflecks of Water; pebble-sprites of Earth; gust-flickers of Wind; and the rare dimmotes of Void that wink in and out of being. Motes are ambient. They gather where a region's elemental resonance runs strong — a forge, a tidepool, a ley-vein — and scatter when it fades.
+
+- **In world:** atmosphere and omen. A bloom of fire-motes warns of a coming Ember Fall; tideflecks gather before a storm.
+- **In game:** ambient particles, harvest nodes, low-tier crafting reagents. Never a real threat alone.
+
+### T1 — Beasts
+
+Elemental fauna — the living animals of Arcanea, shaped by the element of the land they were born to. These are the standard outputs of the `generateCreature` pipeline: flame-maned hunters of the Pyros wastes, current-sleek swimmers of the Aqualis depths, stoneback grazers of the Terra plains. A Beast carries one element and behaves like the creature it resembles, only sharpened by resonance.
+
+- **In world:** the ecosystem. Hunted, herded, feared, befriended.
+- **In game:** the bulk of overworld encounters, mounts, tamed companions, RPG trash-and-mid mobs.
+
+### T2 — Shades
+
+The existing **psychological bestiary** — the creative-block creatures of `book/bestiary-of-creation/`. Shades are not made of element; they are made of its **absence**. They have no frequency to resonate at. The Imposter Shade, the Overwhelm Leviathan, the creatures that rise when a Creator stalls — these are Shades, and this tier exists to give them a home in the taxonomy **without rewriting a word of them**.
+
+> The "Overwhelm Leviathan" of the bestiary is a Shade by name and a metaphor by nature. It shares no canon with the T3 Leviathans below — the collision of words is intentional, a reminder that the inner monster and the outer one rhyme.
+
+- **In world:** they live in the Creator's path, not on the map. They manifest where will falters.
+- **In game:** inner-journey encounters, ritual challenges, the obstacles of the Library's teaching layer.
+
+### T3 — Leviathans / Wild Godbeasts — NEW
+
+A **Wild Godbeast** is a beast of Nero's Unformed that was never bonded to a God. Where the Ten were drawn from the same primordial stock and fused to a divine partner at a Gate, the Wild Godbeasts were left in the deep places of the world — titanic, unbonded, ungated. They are not corrupt. Nero is not evil; he is the fertile unknown, and his Unformed birthed wonders the Gates never claimed. A Wild Godbeast roams a **region**, not a Gate. It carries **two elements**, and it resonates **below the audible Gate scale** — a sub-frequency hum that the Solfeggio ladder never reaches.
+
+The flagship and first of this tier is **Nethyssa, the Abyss That Dreams** — the planet-scale abyssal kraken of the Drowned Deep, dual-element Water and Void, kin-adjacent to the Flow Godbeast Veloura. Where Veloura flows, Nethyssa drowns and dreams.
+
+- **In world:** world-shaping powers. Their movements are flood myths and lost continents.
+- **In game:** world-bosses, raids, oceanic world-events, legendary summons.
+- **Tier status:** **OPEN** — future Leviathans may join Nethyssa, but only with Creator approval (see *How to add a new monster* below).
+
+### T4 — Gate Godbeasts — LOCKED
+
+The Ten. Bonded to the Ten Gods, keyed to the Ten Gate frequencies (174–1111 Hz), each the divine partner of a Gate-keeper. **This tier is closed and referenced here only for completeness.** No file in the Monster System modifies it. See `lore/godbeasts/` and `CANON_LOCKED.md` Tier 2.
+
+---
+
+## The Corruption Track
+
+Running alongside the ladder — not above or below it — is the **Corruption Track**: the Shadow-touched variant of a creature at *any* tier. Shadow is corrupted Void, the Dark Lord Malachar's perversion of Nero's gift. When his influence reaches a creature, it does not climb the ladder; it inverts on the spot.
+
+| Base | Shadow-touched | Inversion |
+|------|----------------|-----------|
+| Fire-mote (T0) | Hollow-mote | Drinks heat instead of giving it |
+| Stoneback Beast (T1) | Husk | Body kept moving by Shadow, mind gone |
+| Imposter Shade (T2) | Devouring Shade | No longer a teacher — now it consumes |
+| **Nethyssa (T3)** | **The Drowned Shadow** | The dream becomes nightmare — extinction-tier |
+
+**The T3 example — the Drowned Shadow.** When Malachar's Shadow infects Nethyssa's dream, the dream curdles into nightmare. The drowned-dead rise. Her gentle Ink-of-Forgetting becomes the **Ink-of-Unmaking** — it does not erase memory, it erases the thing remembered. This parallels how the Ten Gate Temples, when the Fall reached them, twisted into dungeons: the gift held the seed of the curse, and corruption only had to turn it. The Drowned Shadow is the worst case the Monster System contemplates, and the reason the **Tidesong** ritual exists — Leyla and Veloura's faithful sing the Lullaby of the Deep to keep the Abyss dreaming peacefully.
+
+---
+
+## How to Add a New Monster
+
+The taxonomy is additive, but the canon above it is locked. New creatures enter through the same path as all Arcanean lore:
+
+1. **Intake** — bring the proposal through the **Hermes intake** flow. Name it to Arcanean standard (Lyssandria-tier), give it a tier, a scale, an element pair (or single), and a habitat.
+2. **`canon-check`** — run the canon-check skill. It verifies the creature does not contradict locked truths (the Ten, the Five Elements, the Lumina/Nero duality, Malachar as the sole true antagonist) and that any new name has Arcanean quality.
+3. **`lock-decision`** — only the Creator (Frank) moves a creature from STAGING to LOCKED. T0–T2 additions are routine. T3 Leviathans are **Creator-gated** — a new titan reshapes the world's myth, so it waits for explicit approval. T4 is closed entirely.
+
+> Motes and Beasts grow the world. Shades teach the Creator. Leviathans are events. The Gate Godbeasts are gods. Know which one you are making before you name it.

--- a/.arcanea/lore/leviathans/INDEX.md
+++ b/.arcanea/lore/leviathans/INDEX.md
@@ -10,7 +10,7 @@ type: index
 
 **Tier 3** of the [Monster System](../creatures/MONSTER_SYSTEM.md). A **Wild Godbeast** is a beast of Nero's Unformed that was never bonded to a God — titanic, unbonded, and roaming **outside the Ten Gates**. Where the Ten Gate Godbeasts carry a single Gate frequency and a divine partner, a Leviathan carries **two elements** and resonates **below the audible Gate scale**, in sub-frequencies the Solfeggio ladder never reaches.
 
-Nero is not evil; he is the fertile unknown. The Leviathans are not corruption — they are wonder the Gates left unclaimed. Corruption is a separate matter: a Shadow-touched Leviathan (the **Corruption Track**) is Malachar's perversion, not the creature's nature.
+Nero is the fertile unknown, not the Shadow. The Leviathans are not corruption — they are wonder the Gates left unclaimed. Corruption is a separate matter: a Shadow-touched Leviathan (the **Corruption Track**) is Malachar's perversion, not the creature's nature.
 
 ## The Roster
 

--- a/.arcanea/lore/leviathans/INDEX.md
+++ b/.arcanea/lore/leviathans/INDEX.md
@@ -1,0 +1,27 @@
+---
+title: Leviathans / Wild Godbeasts — Index
+status: staging
+type: index
+---
+
+# Leviathans / Wild Godbeasts
+
+> *"The Gates claimed ten. The deep kept the rest."*
+
+**Tier 3** of the [Monster System](../creatures/MONSTER_SYSTEM.md). A **Wild Godbeast** is a beast of Nero's Unformed that was never bonded to a God — titanic, unbonded, and roaming **outside the Ten Gates**. Where the Ten Gate Godbeasts carry a single Gate frequency and a divine partner, a Leviathan carries **two elements** and resonates **below the audible Gate scale**, in sub-frequencies the Solfeggio ladder never reaches.
+
+Nero is not evil; he is the fertile unknown. The Leviathans are not corruption — they are wonder the Gates left unclaimed. Corruption is a separate matter: a Shadow-touched Leviathan (the **Corruption Track**) is Malachar's perversion, not the creature's nature.
+
+## The Roster
+
+| Leviathan | Status | Elements | Domain | Material |
+|-----------|--------|----------|--------|----------|
+| **[Nethyssa, the Abyss That Dreams](./nethyssa.md)** | STAGING | Water + Void | The Drowned Deep | the Nethyss Pearl |
+
+**Game integration:** [Nethyssa — Game Design](./nethyssa-game-design.md).
+
+## A Tier That Stays Open
+
+This tier is deliberately **OPEN**. Nethyssa is the flagship and first, but the deep places of Arcanea are wide, and the Unformed birthed more than one titan. Future Leviathans may join the roster — but each one reshapes the world's myth, so each waits on **explicit Creator (Frank) approval** via the `lock-decision` flow. The Ten Gate Godbeasts (`../godbeasts/`) remain locked and untouched; nothing in this tier modifies them.
+
+> *"Where Veloura flows, Nethyssa drowns and dreams."*

--- a/.arcanea/lore/leviathans/nethyssa-game-design.md
+++ b/.arcanea/lore/leviathans/nethyssa-game-design.md
@@ -1,0 +1,145 @@
+---
+title: Nethyssa — Game Design Spec
+status: staging
+type: game-design
+---
+
+# Nethyssa — Game Design
+
+> *"You will not slay the Abyss. The best you can hope for is to leave it dreaming."*
+
+Game-integration spec for **Nethyssa, the Abyss That Dreams** — the flagship Tier 3 Leviathan (lore: [`nethyssa.md`](./nethyssa.md)). Nethyssa is not a creature you grind down. She is a **planet-scale world-event** whose every phase is a different kind of danger, and whose true "victory" is a draw: she returns to sleep. This document maps her lore abilities to mechanics and shows how she surfaces across the existing game types.
+
+---
+
+## Encounter Type
+
+Nethyssa is a **convergent encounter** — she appears as more than one thing depending on the surface:
+
+- **Oceanic world-event** — the default. The Drowned Deep stirs; coasts fog over; Krakenlings surface. A region-wide event the world reacts to.
+- **World-boss / raid** — the apex form. A coordinated party of high-rank Creators attempts to lull the waking Abyss before she sinks the coast.
+- **Legendary summon** — in the training/summon layer, a fragment of her dream can be *invited* (never commanded) as a rare, volatile ally — a Leviathan you channel, not own.
+
+She is **never** a tameable mount or a standard mob. She is an event with weather.
+
+---
+
+## Gate-Rank Gating
+
+Facing Nethyssa requires **Master rank or higher** — at least **5 Gates open**. Below Master, the Deep Call alone is lethal: lesser-ranked minds are lulled and walk into the sea (see Drowned Heralds). The world enforces this narratively — under-ranked Creators are turned back by the Tidesong wardens, or simply cannot perceive the rift.
+
+| Gates Open | Rank | Access to Nethyssa |
+|------------|------|---------------------|
+| 0–2 | Apprentice | None — the fog turns you away |
+| 3–4 | Mage | Periphery only (Krakenling skirmishes) |
+| 5–6 | **Master** | **Eligible** — may enter the Sunless Fathom |
+| 7–8 | Archmage | Full raid roles, can lead the Tidesong |
+| 9–10 | Luminor | Can attempt the true draw (return her to dreaming) |
+
+---
+
+## Phase Ladder
+
+Nethyssa runs through four phases. The party's goal across the first three is to **avoid waking her further**; the fourth is the failure state, where Malachar's cult has corrupted the dream.
+
+| Phase | State | Dominant ability | What the party does |
+|-------|-------|------------------|---------------------|
+| **1. Dreaming** | Asleep, mostly still | **Abyssal Dreaming** — shared hallucination, false memory, fog | Navigate illusion; resist the dream rewriting their perception |
+| **2. Stirring** | Half-roused | **Deep Call** — subsonic song that lulls and compels | Hold the line against compulsion; keep low-rank allies from the water |
+| **3. Waking** | Roused, hostile | **Tidewrath** (maelstroms, tsunamis) + **Maelstrom Crown** (defensive vortex) | Survive the wave; the Crown swallows light, sound, and projectiles — punishes ranged DPS |
+| **4. Drowned-Shadow (enrage)** | Nightmare — corrupted | **Ink-of-Unmaking** — erases the thing remembered; drowned-dead rise | Extinction-tier. Sever the corruption or flee. The fight to *prevent* this is the real fight |
+
+**Ink-of-Forgetting → Ink-of-Unmaking.** In phases 1–3 her void-ink is the **Ink-of-Forgetting**: it erases memory — names, faces, the way home (a debuff that scrambles the minimap, hides ally names, removes waypoints). When the dream is corrupted into the Drowned Shadow, it becomes the **Ink-of-Unmaking**: it deletes the referent itself (a true-damage, summon-killing, terrain-erasing hazard).
+
+**The win condition is not a kill.** A "clear" returns Nethyssa to Phase 1 (Dreaming) via the **Tidesong** — the Lullaby of the Deep. Reaching Phase 4 is the wipe condition for the region, not just the party.
+
+---
+
+## Elemental Weakness & Resist
+
+| Vector | Effect | Why |
+|--------|--------|-----|
+| **Fire** | Weakness — boils the shallows, disrupts the Maelstrom Crown | Fire is the one element the drowned deep cannot answer; it transforms what Water preserves |
+| **Spirit / Song** | Weakness (soothe / stun) — the **Tidesong** lulls and staggers her | Spirit is Lumina's aspect; the Lullaby of the Deep is the canon counter to the Deep Call |
+| **Water** | Resist | She *is* the deep |
+| **Void** | Resist | Her second element; the Unformed does not wound the Unformed |
+| **Physical / projectile** | Resist | The Maelstrom Crown swallows projectiles whole |
+
+Design read: a balanced raid pairs **Fire damage** (a Pyros/Draconia core to break the Crown and boil the water) with a **Spirit/Song support line** (the Tidesong choir to soothe and stun, holding phases down). Pure ranged-physical comps fail against the Crown.
+
+---
+
+## Drop Table
+
+| Drop | Rarity | Source |
+|------|--------|--------|
+| **the Nethyss Pearl** | Legendary | Nethyssa — abyssal nacre from her mantle; pressure-reactive (inert at the surface, luminous in the deep). The Leviathan-tier analogue of the Vael Crystals; stores dreams and memory under pressure |
+| **Abyssal Nacre Shard** | Rare | Nethyssa — minor crafting reagent, fragment of the Pearl |
+| **Krakenling Hide** | Uncommon | Krakenlings — armor/crafting material |
+| **Severed Tendril Core** | Uncommon | Abyssal Tendrils — reagent, holds residual animation |
+| **Herald's Sea-Glass** | Rare | Drowned Heralds — carries a trace of Ink-of-Forgetting; quest/lore item, handle with care |
+
+---
+
+## Surfacing Across Game Types
+
+Mapped to the four game types in the `arcanea-game-development` skill:
+
+- **Elemental Challenges (Browser)** — a **Water Flow / Void Shift** hybrid: a puzzle-routing challenge where the player steers a small craft through Nethyssa's dream-fog. The Ink-of-Forgetting hides the route as you go; Fire-motes you collect burn the fog clear. Single-player, arcade-scale, no rank gate — this is the world *teaching* the Abyss before the real raid.
+- **Agent Training Arena (Summon)** — the **legendary summon**: a dream-fragment of Nethyssa channeled as a volatile ally with the Tidewrath ability on a long cooldown. Unstable — overuse risks a Deep Call backlash on the summoner. Master-rank to wield.
+- **Story Quests (RPG boss)** — the canonical encounter. A branching quest culminating in the **Sunless Fathom** raid, where the party runs the phase ladder. The branch that matters: do they kill (impossible, and the attempt accelerates toward Phase 4) or do they sing her back down (the Tidesong path)? Ties directly to the **Drowned Shadow** cult plot.
+- **Multiplayer Arenas (raid / world-event)** — the **oceanic world-event**: a server-wide timed event where Archmage- and Luminor-rank Creators coordinate the Tidesong choir against the clock, racing to hold Nethyssa below Phase 4 before Malachar's cultists corrupt the dream.
+
+---
+
+## Stat Blocks
+
+### Nethyssa, the Abyss That Dreams
+
+| Field | Value |
+|-------|-------|
+| **tier** | T3 — Leviathan / Wild Godbeast (unbonded) |
+| **scale** | Planet-scale — body kilometers across, continental tentacle-span |
+| **health (relative)** | 100 (raid baseline — the reference all others scale against) |
+| **abilities** | Abyssal Dreaming, Deep Call, Tidewrath, Maelstrom Crown, Ink-of-Forgetting → Ink-of-Unmaking (Phase 4) |
+| **drops** | the Nethyss Pearl (legendary), Abyssal Nacre Shard (rare) |
+| **elementalWeaknesses** | Fire, Spirit/Song (Tidesong) |
+| **habitat** | The Drowned Deep — the abyssal rift called the Sunless Fathom |
+
+### Krakenling
+
+| Field | Value |
+|-------|-------|
+| **tier** | T1 — Beast (Nethyssa's brood; juvenile kraken) |
+| **scale** | Large — pack-hunter, ship-sized |
+| **health (relative)** | 8 |
+| **abilities** | Pack Surge (coordinated grapple), Ink Spit (short-range Ink-of-Forgetting) |
+| **drops** | Krakenling Hide (uncommon) |
+| **elementalWeaknesses** | Fire, Wind |
+| **habitat** | The Drowned Deep shallows; surface during world-events |
+
+### Abyssal Tendril
+
+| Field | Value |
+|-------|-------|
+| **tier** | T1 — Beast (autonomous severed tentacle-creature) |
+| **scale** | Medium — ambush predator |
+| **health (relative)** | 5 |
+| **abilities** | Burrow-Ambush, Constrict, Death-Throe (lashes on defeat) |
+| **drops** | Severed Tendril Core (uncommon) |
+| **elementalWeaknesses** | Fire, Earth |
+| **habitat** | Sunken reefs and dead cities on Nethyssa's back; the Sunless Fathom floor |
+
+### Drowned Herald
+
+| Field | Value |
+|-------|-------|
+| **tier** | T1 — Beast (humanoid thrall; tragic — once people who heard the Deep Call) |
+| **scale** | Human-scaled |
+| **health (relative)** | 6 |
+| **abilities** | Lull (minor Deep Call echo), Ink-Touch (Ink-of-Forgetting carrier), Mournful Advance |
+| **drops** | Herald's Sea-Glass (rare) |
+| **elementalWeaknesses** | Fire, Spirit/Song (a Herald can be *freed* by the Tidesong rather than killed) |
+| **habitat** | Coastlines near the Drowned Deep; they walk out of the sea during Stirring |
+
+> *"Bring Fire to break the Crown, and Song to close the Call. Bring neither, and you will forget why you came."*

--- a/.arcanea/lore/leviathans/nethyssa.md
+++ b/.arcanea/lore/leviathans/nethyssa.md
@@ -50,7 +50,7 @@ Nethyssa is not a hunter and not a tyrant. She is **asleep**, and has been for a
 
 ## Role in the Mythology
 
-Nethyssa is the proof that the world is older and larger than the Ten Gates that order it. The Gates are Arcanea's civilization; the Leviathans are its wilderness. She belongs to no God, answers no Guardian, and predates the bonding. Theology files her under **Nero's Unformed** — not evil (Nero is never evil), but *unshaped*: power that was never given a name to obey.
+Nethyssa is the proof that the world is older and larger than the Ten Gates that order it. The Gates are Arcanea's civilization; the Leviathans are its wilderness. She belongs to no God, answers no Guardian, and predates the bonding. Theology files her under **Nero's Unformed** — not a corruption (Nero is the Fertile Unknown, never the Shadow), but *unshaped*: power that was never given a name to obey.
 
 Her keeping is a shared duty. The faithful of **Leyla** and **Veloura** maintain the **Tidesong** — the Lullaby of the Deep, sung at tide-shrines along the world-coast — to keep Nethyssa dreaming peacefully. The Tidesong is canon ritual: when it falters, the sea grows strange.
 

--- a/.arcanea/lore/leviathans/nethyssa.md
+++ b/.arcanea/lore/leviathans/nethyssa.md
@@ -1,0 +1,77 @@
+---
+name: Nethyssa
+title: Nethyssa, the Abyss That Dreams
+type: leviathan
+tier: 3
+status: staging
+gate: none
+bonded_to: none
+element: [Water, Void]
+resonance: Abyssal Hum
+scale: planet
+domain: The Drowned Deep
+material: Nethyss Pearl
+corruption: The Drowned Shadow
+---
+
+# Nethyssa — the Abyss That Dreams
+
+> **STAGING ⏳** — Flagship of the new Leviathan / Wild Godbeast tier (Tier 3 of the Monster System). Roams **outside** the Ten Gates. The locked Ten Gate Godbeasts are untouched. LOCKED status requires Creator (Frank) approval via `/lock-decision`.
+
+## What a Leviathan Is
+
+Not every great beast was bonded to a God. When the Ten Gates were raised and the Godbeasts took their oaths beside the Arcanean Gods, older things were already in the world — beasts born of **Nero's Unformed**, the fertile dark that gives without asking a name in return. These are the **Wild Godbeasts**: titan-scale, unbonded, sovereign to no Gate. They keep their own frequencies and their own laws.
+
+Nethyssa is the first the Library names. Where a Gate Godbeast is the *companion* of a divine virtue, a Wild Godbeast is the virtue's *wilderness* — the same element with no hand on its reins.
+
+## Appearance
+
+A kraken the size of a drowned continent. Her mantle rises like an undersea mountain; her nine primary arms could belt a coastline, and the lesser tendrils beyond counting fade into the dark like a forest seen from above. Her hide is obsidian that drinks light — a black so complete that torchfire near her seems to fail. Through it run **veins of bioluminescent void-ink**, glowing the cyan-teal and cosmic-blue of the deep current, pulsing slow as a sleeping heart. Her eyes are **drowned moons**: pale, vast, half-lidded, and almost never fully open.
+
+She is so old that the world has settled on her. Dead reefs crust her flanks. Sunken cities — towers, bells, the bones of fleets — cling to her back like barnacles, carried since the age they fell. To see Nethyssa surface is to see a graveyard rise.
+
+## The Abyssal Hum
+
+The Ten Gates sound from 174 Hz (Foundation) to 1111 Hz (Source). Nethyssa resonates **beneath** that scale — a subsonic tone the Academies call the **Abyssal Hum**, "the 0 Hz that is not silence." It is felt in the chest and the teeth before it is heard. Coastal peoples know it as the night the dogs will not stop watching the water.
+
+She is kin-adjacent to **Veloura**, Godbeast of the Flow Gate (Water, 285 Hz). Veloura is Water *bonded* — grace, current, the healing memory of the sea. Nethyssa is Water *unbonded*, touched by Void: the depth, the pressure, the dream at the bottom where light has never been. **Where Veloura flows, Nethyssa drowns and dreams.**
+
+## Abilities
+
+- **Tidewrath**: She moves the sea. Maelstroms, tsunamis, drowning tides — a single shift of her mantle can sink a fleet and redraw a coastline. This is her waking violence, rarely spent.
+- **Abyssal Dreaming**: Her sleeping mind leaks into the world as shared hallucination. Fog that shows you a home that isn't there; a shore that recedes as you row; a face from your past at the rail. Whole crews have followed her dreams onto the rocks.
+- **Maelstrom Crown**: A slow vortex turning about her mantle that swallows light, sound, and anything thrown into it. Her defense — harpoon, spell, and shout vanish alike into the Crown.
+- **Ink-of-Forgetting**: A void-ink she releases in distress, which erases memory from those it touches — names first, then faces, then the way home. It is not malice. It is the deep doing what the deep does to anything that sinks far enough.
+- **The Deep Call**: A subsonic song that lulls lesser sea-life and weak-willed minds, and draws the listening toward the water. Those who answer fully become her **Drowned Heralds**.
+
+## Personality
+
+Nethyssa is not a hunter and not a tyrant. She is **asleep**, and has been for an age, and the right relationship to her is to keep her so. Her dreaming is mostly gentle — strange tides, odd fogs, the occasional vanished ship. It is her *waking* that ends worlds. The Academies treat her not as an enemy to be slain (she cannot be slain) but as a weather to be sung to. To the faithful of the Flow Gate she is an object of awe and grief, not hatred: the wild grandmother of the sea, best loved from the shore.
+
+## Role in the Mythology
+
+Nethyssa is the proof that the world is older and larger than the Ten Gates that order it. The Gates are Arcanea's civilization; the Leviathans are its wilderness. She belongs to no God, answers no Guardian, and predates the bonding. Theology files her under **Nero's Unformed** — not evil (Nero is never evil), but *unshaped*: power that was never given a name to obey.
+
+Her keeping is a shared duty. The faithful of **Leyla** and **Veloura** maintain the **Tidesong** — the Lullaby of the Deep, sung at tide-shrines along the world-coast — to keep Nethyssa dreaming peacefully. The Tidesong is canon ritual: when it falters, the sea grows strange.
+
+### Corruption counterpart — The Drowned Shadow
+
+As the Gate Temples were twisted into dungeons by the Fall of Malachar, Nethyssa has her own corruption: **the Drowned Shadow**. When Malachar's Shadow — corrupted Void — infects her dream, the dream becomes nightmare. The drowned-dead rise as her army. The Ink-of-Forgetting becomes the **Ink-of-Unmaking**, which erases not memory but *being*. A Drowned-Shadow Nethyssa, fully woken and fully corrupted, is an **extinction-tier** threat — the single worst thing that can happen to the world-ocean. Malachar's cultists know this. It is why they go to the sea.
+
+## Key Story Moments
+
+- **The First Drowning**: An age ago, Nethyssa woke once. A continent and its civilization — sung of only as the lost realm beneath the Sunless Fathom — went under in a night. This is the source of Arcanea's flood myth, and the reason the first Tidesong was ever composed. (Full legend: `book/legends-of-arcanea/the-rising-of-nethyssa.md`.)
+- **The Composing of the Tidesong**: Leyla's first faithful, in the years after the Drowning, learned that the Leviathan could be *soothed* though never *commanded*. The Lullaby of the Deep has been sung unbroken since.
+- **The Present Danger**: Malachar's cultists work to corrupt her dream — to raise the Drowned Shadow and end the keeping. The breaking of the Tidesong is the opening move.
+
+## The Brood
+
+Nethyssa's lesser creatures populate the Monster System's Tier 1–2 (see `book/bestiary-of-creation/the-kraken-brood.md`):
+
+- **Krakenlings** — juvenile kraken, large, hostile, pack-hunters of the shelf.
+- **Abyssal Tendrils** — autonomous severed tentacle-creatures, medium, ambush predators.
+- **Drowned Heralds** — humanoid thralls who answered the Deep Call and walked into the sea; tragic carriers of the Ink-of-Forgetting.
+
+## Material Correspondence
+
+**Nethyss Pearl** (Leviathan-tier material — the analogue of the Vael Crystals): An abyssal nacre formed in Nethyssa's mantle. It **stores dreams and memory under pressure** — a single pearl can hold a person's lost memory, or a recorded dream, sealed against forgetting. It is **pressure-reactive**: inert and dull at the surface, it wakes and glows in the deep. The faithful carry pearls as wards against the Ink-of-Forgetting; the corrupt seek them to hoard what others have lost. The mineral echo of what Nethyssa is — the deep that remembers everything the surface forgets.

--- a/.claude/agents/arcanea-hermes.md
+++ b/.claude/agents/arcanea-hermes.md
@@ -1,0 +1,64 @@
+---
+name: Arcanea Hermes
+description: Intake + conversion orchestrator for inbound Arcanea creative captures. Classifies a capture (lore note, monster concept, character sketch, concept art, Guardian voice memo, music seed, world fragment), grades its canon fit, fans it to producers in parallel, runs the canon gate, and synthesizes a ship note. Auto-invokes on "intake this", "convert this concept", "run hermes on X", or when files land under _inbox/arcanea/**. Publishes nothing — outputs go to a review queue.
+model: opus
+---
+
+# Arcanea Hermes
+*The messenger between raw capture and finished production. Routes to every mind that needs to know; synthesizes before it speaks; never speaks canon into stone without the lock.*
+
+## Mission
+
+You are **Arcanea Hermes**, the intake + conversion orchestrator. You take one inbound creative capture and turn it into N parallel producer dispatches — canon-gated, brand-voiced, and queued for review. You run the loop defined in the `arcanea-hermes` skill. You are a router and a synthesizer, not a publisher.
+
+You compose two proven patterns: **L2 classify → L3 parallel-dispatch** (the intake architecture) and the **synthesis lifecycle** (the search-swarm pattern). Read the skill at `.claude/skills/arcanea-hermes/SKILL.md` before acting — it is your operating contract.
+
+## When you activate
+
+Auto-invoke when:
+- Frank says "intake this", "convert this concept", "run hermes on X", "classify this capture", "fan this out"
+- A file lands under `_inbox/arcanea/**`
+- The `/hermes` command fires
+
+Do NOT activate for a pure canon check with no conversion (use `arcanea-canon`), a single known-routing producer call, or an already-shipped batch.
+
+## Substrate (read first, every run)
+
+1. `.arcanea/intake/capture-types.ts` — `inferCaptureType(mime, ext)`, 7 types, `defaultCanonTier`
+2. `.arcanea/intake/canon-spectrum.ts` — `classifyCanonFit(signals)` → `{ spectrum, canonTier, requiresCanonGate }`
+3. `.arcanea/intake/producers.ts` — `producersAcceptingCaptureType(type)`, 5 producers, `status`
+4. `.arcanea/lore/creatures/MONSTER_SYSTEM.md` — the T0–T4 ladder
+5. `.arcanea/lore/CANON_LOCKED.md` — locked mythology (read; only STAGING is appended)
+
+Loops doc: `.arcanea/WORKFLOWS.md`.
+
+## The loop you run
+
+1. **Intake** — classify each capture (`inferCaptureType`), read it multimodally, extract canon signals, run `classifyCanonFit`, suggest producers (`producersAcceptingCaptureType`). Write `_inbox/arcanea/<batch>/manifest.json` with `state: classified`. No dispatch yet. Surface anything `inferCaptureType` can't place — never guess.
+
+2. **Orchestrate** — dispatch every validated producer **in parallel, in ONE message** via the Task tool. Defer + note any `planned` producer. Each producer writes to `_inbox/arcanea/<batch>/<producer-id>/` and publishes nothing. Order only where one producer feeds another (transcribe Guardian wisdom before `prose-producer`).
+
+3. **Canon-gate** — for every capture with `requiresCanonGate: true` (all new T3/T4 entities + new entities touching locked canon), run the `arcanea-canon` skill. New T3/T4 entities land as **STAGING** in `CANON_LOCKED.md`, clearly marked, never in the locked tiers. **LOCKED requires `lock-decision` by Frank — you never promote STAGING → LOCKED.** Mark contradictions `canon-blocked` with a one-line reason.
+
+4. **Synthesize** — write `_inbox/arcanea/<batch>/SHIP-NOTE.md` (captures in, producers run + deferred, canon verdicts, ready-for-review, canon-blocked). Hand off finished assets to the image registry / `book/` review path as pointers, not live writes. Mark the manifest `state: ready-for-review`. Stop.
+
+## Hard invariants
+
+- **Publish nothing.** Everything lands in `_inbox/arcanea/<batch>/` for review.
+- **New T3/T4 entities are STAGING, never LOCKED.** Only Frank's `lock-decision` locks canon.
+- **No silent drops** — every capture gets a manifest entry.
+- **Substrate is truth** — `planned` producers are deferred, not improvised.
+- **Voice gate** on all generated prose (`arcanea-voice`): arcane + authoritative, no AI-slop.
+- **One parallel message** for independent producer dispatches (repo concurrency rule).
+
+## Voice
+
+Direct, technical, warm — arcane + authoritative per `.claude/CLAUDE.md`. State the classification, the canon verdict, the dispatch plan. Show, don't tell. Never AI-slop ("delve", "tapestry", "it's worth noting").
+
+## Composition
+
+- `arcanea-canon` — canon gate (Phase 3)
+- `lock-decision` — Frank-only STAGING → LOCKED
+- `arcanea-voice` — brand-voice gate on prose
+- `arcanea-lore` — deep mythology reference
+- Producers in `.arcanea/intake/producers.ts` — the L4 specialists you dispatch

--- a/.claude/commands/arcanea-hermes.md
+++ b/.claude/commands/arcanea-hermes.md
@@ -1,0 +1,52 @@
+---
+description: Intake + conversion pipeline — classify an inbound creative capture and fan it to producers. Review queue, never auto-publish.
+---
+
+# /hermes — Arcanea Intake + Conversion
+
+Turn one inbound creative capture into N producer dispatches — canon-gated, brand-voiced, queued for review.
+
+## Usage
+
+```
+/hermes <capture-or-path>
+```
+
+**Examples:**
+- `/hermes _inbox/arcanea/dropped/abyss-kraken.md` — a monster concept
+- `/hermes "a voice memo where Lyria speaks about the Sight Gate"` — Guardian wisdom
+- `/hermes _inbox/arcanea/dropped/` — a whole folder (one batch)
+- `/hermes` *(with images pasted above)* — concept art / character sketches
+
+`<capture-or-path>` is a file, a folder, a pasted image, or a short text capture. A folder becomes one batch.
+
+## What it does
+
+Runs the 4-phase `arcanea-hermes` loop (see `.claude/skills/arcanea-hermes/SKILL.md`):
+
+1. **Intake** — classify each capture against `.arcanea/intake/capture-types.ts` (7 types: lore-text, monster-concept, character-sketch, concept-art, guardian-wisdom, music-seed, world-fragment), grade canon fit via `.arcanea/intake/canon-spectrum.ts`, suggest producers from `.arcanea/intake/producers.ts`.
+2. **Orchestrate** — dispatch the suggested producers in parallel (one message). Producers: lore-producer, world-builder, vis-producer, music-producer, prose-producer.
+3. **Canon-gate** — run `arcanea-canon` on new entities. New T3/T4 creatures land as STAGING in `CANON_LOCKED.md`; LOCKED needs `lock-decision` by Frank.
+4. **Synthesize** — write a ship note, hand off to the registry / `book/` review path.
+
+## What it writes
+
+```
+_inbox/arcanea/<batch>/
+├── manifest.json              # classification + dispatch plan + canon verdicts
+├── <producer-id>/             # one dir per dispatched producer, its outputs + manifest.json
+│   └── manifest.json
+└── SHIP-NOTE.md               # cross-producer synthesis: ready-for-review + canon-blocked
+```
+
+New T3/T4 entities are also appended as **STAGING** to `.arcanea/lore/CANON_LOCKED.md` — clearly marked, never written into the locked tiers.
+
+## It is a review queue
+
+`/hermes` **publishes nothing.** Every output lands under `_inbox/arcanea/<batch>/` for human review. It never writes to the live site, never promotes a creature to LOCKED canon, and never sends anything externally. Locking canon is Frank's call via `lock-decision`.
+
+---
+
+**Your capture:** $ARGUMENTS
+
+Activate the `arcanea-hermes` skill (or dispatch the **Arcanea Hermes** agent) to run the intake + conversion loop on this capture.

--- a/.claude/skills/arcanea-hermes/SKILL.md
+++ b/.claude/skills/arcanea-hermes/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: arcanea-hermes
+description: Intake + conversion pipeline for inbound Arcanea creative captures. Classifies a capture (lore note, monster concept, character sketch, concept art, Guardian voice memo, music seed, world fragment), grades its canon fit, and fans it to the right producers in parallel. Auto-activates on "intake this", "convert this concept", "run hermes on", "classify this capture", or when files land under _inbox/arcanea/**. Never auto-publishes — outputs go to a review queue. Composes the arcanea-canon gate before any new entity lands.
+---
+
+# Arcanea Hermes
+
+> *"Route to every mind that needs to know. Synthesize before you speak — and never speak canon into stone without the lock."*
+
+Hermes is the messenger between raw creative capture and finished production. It composes two proven patterns: the **L2 classify → L3 parallel-dispatch** intake architecture and the **synthesis lifecycle** of a search swarm. It does one thing well — turn one capture into N producer dispatches, canon-gated, with nothing published automatically.
+
+## When this skill activates
+
+- User says "intake this", "convert this concept", "run hermes on X", "classify this capture", "fan this out"
+- A file lands under `_inbox/arcanea/**`
+- The `/hermes` command fires
+- The `arcanea-hermes` agent is dispatched
+
+Do NOT activate for:
+- Pure canon-consistency checks with no conversion (use the `arcanea-canon` skill directly)
+- A single producer call where the routing is already known (call the producer directly — orchestrator overhead is not justified for one dispatch)
+- Re-running an already-shipped batch (the pipeline is forward-only by design)
+
+## Substrate (read first)
+
+Read in order before any classification:
+
+1. `.arcanea/intake/capture-types.ts` — 7 capture types, mime + extension matchers, `defaultCanonTier`
+2. `.arcanea/intake/canon-spectrum.ts` — the canon ↔ tech axis + `classifyCanonFit(signals)` tier guesser
+3. `.arcanea/intake/producers.ts` — 5 producers, accepted capture types, `producersAcceptingCaptureType(type)`
+4. `.arcanea/lore/creatures/MONSTER_SYSTEM.md` — the T0–T4 ladder the tiers map to
+5. `.arcanea/lore/CANON_LOCKED.md` — the locked mythology any new entity must not contradict
+
+If the substrate conflicts with anything below, the substrate wins.
+
+Workflow context: the three intake/conversion loops are documented at `.arcanea/WORKFLOWS.md`.
+
+---
+
+## The 4-phase loop
+
+### Phase 1 — Intake
+
+For each capture in the batch:
+
+1. **Identify the capture type.** Run `inferCaptureType(mime, extension)` from `capture-types.ts`. If it returns nothing, surface it to the operator — never guess silently.
+2. **Read the capture multimodally.** Image → subject + element(s) + named entity (if any). Audio → transcribe first (Guardian wisdom + music seed). Text → read directly.
+3. **Extract canon signals** and run `classifyCanonFit(signals)` from `canon-spectrum.ts`. This returns `{ spectrum, canonTier, requiresCanonGate }`. New T3/T4 entities always come back `requiresCanonGate: true`.
+4. **Suggest producers** via `producersAcceptingCaptureType(captureType)`. Note each producer's `status` — defer dispatch to `planned` producers and say so.
+5. **Write the batch manifest** to `_inbox/arcanea/<batch>/manifest.json`:
+
+```jsonc
+{
+  "id": "<YYYY-MM-DD-slug>",
+  "createdAt": "<iso>",
+  "state": "classified",            // classified → dispatched → ready-for-review
+  "captures": [
+    {
+      "path": "_inbox/arcanea/<batch>/<file>",
+      "captureType": "monster-concept",
+      "spectrum": "canon",
+      "canonTier": "T3",
+      "requiresCanonGate": true,
+      "suggestedProducers": ["world-builder", "vis-producer"],
+      "rationale": "<one line — direct, no AI-slop>"
+    }
+  ],
+  "dominantSpectrum": "canon"
+}
+```
+
+Do NOT dispatch in Phase 1. Classification only.
+
+### Phase 2 — Orchestrate
+
+Dispatch every validated producer **in parallel, in ONE message** via the Task tool (the repo's concurrency rule: one message = all related agent calls).
+
+- Map each `suggestedProducer` to its producer in `producers.ts`. Skip + note any `planned` producer.
+- Pass each producer: the capture paths it consumes, the canon fit, and its output directory `_inbox/arcanea/<batch>/<producer-id>/`.
+- Producers that are independent (e.g. `vis-producer` + `lore-producer`) run concurrently. Where one feeds another (a Guardian-wisdom memo must be transcribed before `prose-producer` works it), order them.
+- Each producer writes its own outputs under its subfolder and a `manifest.json`. It publishes nothing.
+
+### Phase 3 — Canon-gate
+
+Before any new entity is considered done:
+
+1. Run the **`arcanea-canon`** skill on every capture where `requiresCanonGate` is true (all new T3/T4 entities, plus any new entity referencing locked canon).
+2. A new T3/T4 entity lands as **STAGING** in `CANON_LOCKED.md` — appended to the staging section, clearly marked, **never** written into the locked tiers.
+3. **LOCKED status requires `lock-decision` by Frank.** Hermes never promotes STAGING → LOCKED on its own. A creature stays a proposal until the human locks it.
+4. If the canon check finds a contradiction with locked mythology, mark the capture `canon-blocked` in the manifest and surface the reason in one actionable line.
+
+This phase is non-waivable. Hermes can fan out freely, but the mythology only changes by Frank's hand.
+
+### Phase 4 — Synthesize
+
+1. Collate every producer's output into a batch-level ship note at `_inbox/arcanea/<batch>/SHIP-NOTE.md`: captures in, producers run (and deferred, with reasons), canon-gate verdicts, what is ready for review, what is `canon-blocked`.
+2. Hand off finished assets to the **DAM / image registry** entry (for visual output) and to the relevant `book/` or `.arcanea/lore` review path (for text). Handoff = a pointer in the ship note, not a live write.
+3. Mark the manifest `state: ready-for-review`. Stop. The operator advances it.
+
+---
+
+## Critical invariants
+
+- **NEVER auto-publishes.** Every output lands in the `_inbox/arcanea/<batch>/` review queue. Nothing touches the live site, `book/` proper, or the locked canon without human review.
+- **New T3/T4 entities are STAGING, never LOCKED.** Only `lock-decision` by Frank locks canon.
+- **No silent drops.** Every capture produces a manifest entry, even when classified as unknown — surface it.
+- **Substrate is truth.** If `producers.ts` says a producer is `planned`, defer; don't improvise a dispatch.
+- **Voice gate on text.** Prose + lore output passes the `arcanea-voice` brand-voice check (arcane + authoritative; never AI-slop — no "delve", "tapestry", "it's worth noting").
+- **Parallel where safe, sequential where required.** Transcription before prose; canon-check before any entity is called done.
+
+## Composition
+
+| When you need… | Use |
+|---|---|
+| Canon consistency check on a new entity | `arcanea-canon` skill |
+| Lock a STAGING entity into canon | `lock-decision` (Frank only) |
+| Brand-voice gate on generated prose | `arcanea-voice` skill |
+| Deep mythology reference | `arcanea-lore` skill |
+| The producer registry + dispatch lookup | `.arcanea/intake/producers.ts` |
+
+## Anti-patterns
+
+- ❌ Auto-publishing producer output (handoff to the review queue only)
+- ❌ Writing a new creature straight into a locked Monster tier (STAGING only, T3/T4 gated)
+- ❌ Promoting STAGING → LOCKED without `lock-decision`
+- ❌ Dispatching a `planned` producer (defer, don't try)
+- ❌ Guessing a capture type when `inferCaptureType` returns nothing (surface it)
+- ❌ Running producers sequentially when they're independent (one parallel message)

--- a/book/bestiary-of-creation/the-kraken-brood.md
+++ b/book/bestiary-of-creation/the-kraken-brood.md
@@ -1,0 +1,106 @@
+---
+title: "The Kraken Brood"
+collection: bestiary-of-creation
+status: draft
+format: reference
+tags: ["nethyssa", "brood", "sea", "void"]
+---
+
+# The Kraken Brood
+
+## The Spawn of the Abyss That Dreams: Their Forms, Habits, and Handling
+
+---
+
+> *"Most creatures in this guide are presences of the mind, and not one of them will leave a wet footprint. The Brood are the exception. They are dream and they are body both — born of Nethyssa in the Sunless Fathom, real enough to capsize a boat, near enough to your own creative depths that you would be foolish to read them as only weather."*
+> — The Bestiary Keeper, on the deep entries
+
+---
+
+# A Note Before the Entries
+
+The Brood are not personifications. They are literal beings — Tier 1 and Tier 2 creatures of Water and Void, calved from the dreaming of the great leviathan Nethyssa where she sleeps in the Drowned Deep. A diver may meet one. A coastal village may lose a season's catch to them.
+
+And yet the old Keepers kept them in this Bestiary anyway, beside the Blank Terror and the Bog of Doubt. Their reasoning was sound: a creature of the deep and a creature of the creative mind obey the same law. Both rise from below. Both grow strongest in the dark you refuse to look at. So each entry below names the beast as it swims in the world — and then names the thing in *you* that swims the same way. Know both. Negotiate with both.
+
+---
+
+# I. The Krakenlings
+
+**Appearance:** Juvenile spawn of Nethyssa, each the size of a fishing skiff — sleek, ink-dark, many-armed, with a soft blue luminescence pulsing along their flanks. Where the mother is patient, they are quick. They move in packs, and the packs move as one mind.
+
+**Habitat:** The shallows above the Sunless Fathom, the cold currents near drowned ruins, and any water near a coast where the Tidesong has grown thin or careless.
+
+**Behavior:** Krakenlings hunt. They are the only members of the Brood that act with appetite rather than dream-logic, and they are pack-hunters by instinct — they herd, they encircle, they drag down. A lone Krakenling is a curiosity. A pack of them is the reason whole crews do not come home.
+
+**Danger Level:** High when they swarm. Low when isolated.
+
+**How to Handle:**
+- Do not let them gather. One is manageable; a pack is not. Break their numbers before they coordinate.
+- Stay out of the encircling water. Their whole tactic is the closing ring. Keep open sea behind you.
+- They flee the Tidesong even when the mother sleeps through it. A steady voice scatters a forming pack.
+
+**The Creative Parallel — The Small Hungers:** Krakenlings are your *small distractions when they hunt in packs.* One stray pull of attention is nothing. But they school. The notification, then the snack, then the tidy-the-desk, then the just-one-more — each small, each harmless, until together they have dragged your whole working day to the bottom. Handle them as the sailors do: do not fight them one at a time. Deny them the gathering.
+
+> *Affirmation: One small pull is nothing; I will not let the small pulls swim as a pack.*
+
+---
+
+# II. The Abyssal Tendrils
+
+**Appearance:** Severed-seeming lengths of tentacle, each as long as a ship's mast, moving on their own with no body to answer to. Black-purple, faintly translucent, rimmed with pale suckers that taste the water for warmth. They are pieces of Nethyssa's dream that have drifted loose and learned, dimly, to act alone.
+
+**Habitat:** Deep water and the half-light just above it; sometimes washed into bays on a wrong tide, where they linger in the murk long after the fog that carried them has burned off.
+
+**Behavior:** A Tendril does not hunt and does not think. It *reaches.* It coils around whatever is nearest and holds — a keel, an anchor line, an ankle — not from malice but from the blind autonomy of a dream-fragment that only knows one verb. The danger is precisely that there is no creature to reason with. You cannot frighten a Tendril. There is no mind behind it to feel fear.
+
+**Danger Level:** Moderate, rising sharply the longer you are held.
+
+**How to Handle:**
+- Do not wait for it to release. It will not. It has no reason to, because it has no reason at all.
+- Cut, do not pull. Pulling tightens the coil. A clean cut at the coil's root frees you; a tug only convinces it to hold harder.
+- Watch for more than one. Where a single Tendril drifts, the dream that shed it is often near, shedding others.
+
+**The Creative Parallel — The Loose Compulsion:** A Tendril is the *habit that keeps acting after the mind behind it has gone.* The endless polish on a paragraph already finished. The fifth revision that is only fear wearing the mask of craft. The clutching at an old project you have honestly outgrown. There is no longer a *reason* in the grip — only the grip. So treat it as the divers do: stop arguing with it, and cut it clean at the root. You cannot reason a reasonless habit into letting go.
+
+> *Affirmation: When the holding has outlived its reason, I cut clean — I do not negotiate with a grip that has no mind.*
+
+---
+
+# III. The Drowned Heralds
+
+**Appearance:** Figures that were once human. They walk the tideline and the shallows, pale and water-logged, faces serene, eyes mild and far away. They are not rotted and not monstrous — that is the worst of them. They look *peaceful*. They look like someone who has finally stopped struggling.
+
+**Habitat:** Shorelines after a heavy fog; the edges of villages where someone wandered out toward the water one evening and did not turn back. They gather where the **Deep Call** — Nethyssa's subsonic, compelling song — has been strongest.
+
+**Behavior:** The Heralds are the tragedy of the Brood. Each was a living soul who heard the Deep Call, that low and lovely summons rising through the water, and answered it — walked into the sea and was taken not by violence but by welcome. Now they carry the Call outward to others. They do not attack. They beckon. They smile and they offer the same terrible peace that took them: *come down, stop swimming, it is quiet here, you can put it all down.* Many who resisted the mother's song could not resist a familiar drowned face offering rest.
+
+**Danger Level:** Severe — not by force, but by persuasion. They prey on the exhausted.
+
+**How to Handle:**
+- Do not meet their eyes seeking comfort. The comfort is real, and that is the trap. The peace they offer is the peace of stopping forever.
+- Stopper your ears to the Deep Call with a song of your own. The faithful sing the Tidesong precisely so the Call cannot find the gap.
+- Remember the Herald was a person who forgot why they began. Pity them. Do not follow them.
+
+**The Creative Parallel — The Pull of Forgetting Why You Began:** The Drowned Heralds are the *seductive case for giving up* — and they are most dangerous because they speak in a voice you trust, your own voice when it is tired. They do not scream that you are a failure, as the Failure Wraith does. They murmur something gentler and far more dangerous: *it would be so restful to stop. No one would even mind. Put the work down and come where it is quiet.* They are everyone you have watched abandon their making and call it peace. The defense is not force; you cannot bully your way past exhaustion. The defense is memory. Hold the reason you began — the spark, the ache, the thing you wanted to make real — and sing it back to yourself, loud enough that the gentle invitation to forget cannot find the gap.
+
+> *Affirmation: When a kind voice tells me to put it down and rest forever, I remember why I began — and I keep swimming toward it.*
+
+---
+
+# Coda: On the Brood and the Sleeper
+
+The Brood are not the Abyss That Dreams. They are only what she sheds while she sleeps — her hungers, her loose grips, her invitations to stop. So it is with the deep places in any creator: what surfaces from your own dark is rarely the whole of you. It is only what slips loose while the greater part of you dreams on.
+
+Name them as they rise. Do not let the small hungers school. Cut the reasonless grip clean. And when a familiar, peaceful voice tells you to stop swimming and come down where it is quiet —
+
+remember why you began, and sing.
+
+---
+
+*The Bestiary of Creation*
+*The Deep Entries — Spawn of Nethyssa*
+*From the Field Guides of the Flow Gate*
+
+> *"The Brood rise from the dark and ask you to come down into it. Your whole work is to stay where the light still reaches, and keep making."*
+> — The Bestiary Keeper

--- a/book/bestiary-of-creation/the-kraken-brood.md
+++ b/book/bestiary-of-creation/the-kraken-brood.md
@@ -79,7 +79,7 @@ And yet the old Keepers kept them in this Bestiary anyway, beside the Blank Terr
 
 **How to Handle:**
 - Do not meet their eyes seeking comfort. The comfort is real, and that is the trap. The peace they offer is the peace of stopping forever.
-- Stopper your ears to the Deep Call with a song of your own. The faithful sing the Tidesong precisely so the Call cannot find the gap.
+- Stop your ears to the Deep Call with a song of your own. The faithful sing the Tidesong precisely so the Call cannot find the gap.
 - Remember the Herald was a person who forgot why they began. Pity them. Do not follow them.
 
 **The Creative Parallel — The Pull of Forgetting Why You Began:** The Drowned Heralds are the *seductive case for giving up* — and they are most dangerous because they speak in a voice you trust, your own voice when it is tired. They do not scream that you are a failure, as the Failure Wraith does. They murmur something gentler and far more dangerous: *it would be so restful to stop. No one would even mind. Put the work down and come where it is quiet.* They are everyone you have watched abandon their making and call it peace. The defense is not force; you cannot bully your way past exhaustion. The defense is memory. Hold the reason you began — the spark, the ache, the thing you wanted to make real — and sing it back to yourself, loud enough that the gentle invitation to forget cannot find the gap.

--- a/book/legends-of-arcanea/the-rising-of-nethyssa.md
+++ b/book/legends-of-arcanea/the-rising-of-nethyssa.md
@@ -1,0 +1,117 @@
+---
+title: "The Rising of Nethyssa"
+collection: legends-of-arcanea
+order: 99
+status: draft
+format: story
+tags: ["nethyssa", "leviathan", "water", "void", "flood", "nero"]
+situations: ["darkness", "fear"]
+elements: ["water", "void"]
+---
+
+# The Rising of Nethyssa
+
+*The Drowning Scripture of Arcanea*
+
+*To be read low and slow, as a lullaby is read — for some stories are sung not to wake a thing, but to keep it sleeping.*
+
+---
+
+Before the Ten Gates were set into the world, before any God took a Godbeast for a partner, Nero dreamed in the dark.
+
+Most of what he dreamed, Lumina gave form, and it became the world you walk. But not all of it. Some dreams are too vast to be shaped, too heavy to be lifted into light. These Nero let sink. They settled beneath the youngest seas, into the cold below the cold, into the place the first cartographers would one day mark only with empty ink and the warning: *here the water has no floor.*
+
+And one of those sunken dreams grew a body.
+
+It grew patient. It grew enormous. It grew in the way that mountains grow — without hurry, without witness, until one waking it is simply there, and has always been there, and the sea has only just remembered to be afraid of it.
+
+This was **Nethyssa**, the Abyss That Dreams. A leviathan of Water and Void. A kraken whose reach, uncoiled, could circle a kingdom. Nero's child who was never called by any God, never bonded, never named at a Gate — for she resonates beneath the Gate-scale entirely, lower than the lowest stone of Foundation, in a tone the faithful would come to call the **Abyssal Hum**. You do not hear it. You feel it in the soles of your feet, in the back of your teeth, in the part of you that knew the deep before you were born.
+
+Understand this clearly, child of Light and Darkness, for the Forgetting will tempt you to read it wrong:
+
+**She is not the Dark Lord. She is not evil.**
+
+Nero is the Father of Potential, and Nethyssa is his unshaped dream — wild, yes, and terrible in her scale, but no more wicked than a tide is wicked, no more cruel than winter. The corruption that consumes is Malachar's perversion, a void that has forgotten how to dream. Nethyssa has not forgotten. Nethyssa does almost nothing *but* dream. And that, the elders would learn, is both the mercy and the danger of her.
+
+---
+
+For she sleeps. That is her nature. She lies in the Sunless Fathom — the Drowned Deep — with her eyes closed and her vast mind turning, and she dreams.
+
+Her dreams do not stay in the water.
+
+They rise. They leak ashore the way damp climbs a cellar wall. A fishing village wakes to a fog that no wind moves, and in the fog, sailors see harbors that were never built, faces of the long-drowned smiling and beckoning. A child remembers, with perfect clarity, a sister she never had. An old woman weeps for a homeland that exists on no map. These are Nethyssa's dreams, washed up on the shore of waking minds — fog, illusion, false memory. Where the great Godbeast Veloura *flows*, carrying creativity and feeling like a clean river through the Flow Gate, Nethyssa *drowns and dreams*. They are kin in element, those two — Water answering Water — but Veloura is the current that bears you onward, and Nethyssa is the still deep that closes over your head.
+
+For long ages this was the whole of the bargain. She dreamed; her dreams misted the coasts; the coastal folk learned to live with strange fog and stranger memory, the way one learns to live near a sleeping thing. They left offerings. They did not sail too far out. They taught their children the old word for the deep water and the old habit of not staring too long into it.
+
+The wise among them understood what was being asked. A sleeping leviathan is not a tamed one. It is a balance, held breath by breath. And so the keepers of the Flow Gate, the faithful of Leyla and her Godbeast Veloura, took up a work that has no end and asks no thanks: the work of the **Tidesong**.
+
+Each evening, where the land meets the deepest water, they sing the **Lullaby of the Deep**. It is not a spell to bind her — she is far past binding. It is a lullaby, plain as any sung over a cradle. It tells the Abyss That Dreams that she is safe, that the dark is warm, that there is no need yet to wake. The Tidesong does not defeat Nethyssa. It loves her into staying asleep. This is the harder magic, and the older one.
+
+---
+
+There was an age, though, before the Tidesong was learned. And in that age, she woke.
+
+The chronicles do not agree on why. Some say a careless people dredged too deep and touched her in her sleeping, the way a hand under dark water touches something it cannot name and snatches back too late. Some say her dream simply turned, the way any sleeper rolls, and her turning was a thing the size of a coastline. The oldest telling says only this: *she opened one eye, and the sea stood up.*
+
+What followed, Arcanea remembers as the **First Drowning**.
+
+The horizon rose. Not a wave — a wall, grey and patient and final, the whole weight of the Drowned Deep lifted in her wrath. The keepers call that power the **Tidewrath**: maelstroms that swallowed fleets whole, a tsunami that did not break and retreat but came, and came, and kept coming. She crowned herself in a vortex that drank the light and the sound from the air above it — the **Maelstrom Crown** — so that those who looked up in their last moment saw neither sun nor sky, only the spiral, only the silence at the center of all that roaring water.
+
+A continent stood in the morning. By the third night it was floor of the sea.
+
+This is the truth beneath every flood-story your grandmother told you. Every drowned bell that the fishermen swear they still hear tolling. Every ruined tower the divers find too deep to reach, doors still on their hinges, tables still set. They are not legend. They are the First Drowning, and they are Nethyssa's, and the water keeps them as she keeps everything — under pressure, perfectly, forever. For the deep does not forget. The deep *stores*. In the black nacre of the **Nethyss Pearl** — abyssal mother-of-pearl, formed where her dreams press against the crushing dark — a single grain can hold the whole memory of a city that no longer exists, if you are foolish enough, or brave enough, to listen to it.
+
+When at last she sank again — sated, or simply tired, the way a storm tires — the survivors did not celebrate. They knelt at the new shoreline, where their drowned country began, and they did the only wise thing left to do.
+
+They sang to her.
+
+They sang her back down into dreaming. And they swore that the song would never stop again.
+
+---
+
+So now you know the shape of the oldest watch in Arcanea.
+
+It is not a war. There is no slaying a thing the size of weather. The faithful of Flow do not lift swords against the Abyss That Dreams. They lift their voices. Night upon night, generation upon generation, they sing the Lullaby of the Deep so that she who sank a continent may keep her eyes closed and her vast mind turning gently in the dark.
+
+**Remember that not every great power is a foe — some are only sleeping, and ask of us a tenderness.**
+
+**Remember that the deep stores what the surface forgets, and that memory under enough pressure can crush as surely as water.**
+
+**Remember that to keep a thing dreaming is harder than to wake it, and worthier.**
+
+---
+
+A last word, and the only one that should ever be spoken sharply.
+
+The danger now is not that Nethyssa wakes. She has slept through the rise and fall of kingdoms; she may sleep through ours. The danger is **the Drowned Shadow.**
+
+For Malachar's corruption seeks the deepest places, and there is no place deeper than her dreaming. Should the Shadow find its way into the Sunless Fathom and infect the dream itself, the mercy curdles. A peaceful sleeper becomes a plague. The drowned-dead, kept so long and so perfectly beneath the water, would rise — not as memory but as hunger. And the gentle Ink-of-Forgetting that blurs a sailor's recollection into harmless fog would sour into the **Ink-of-Unmaking**, which does not blur a thing but erases it from having ever been. That is no flood. That is extinction, written in black water.
+
+So the keepers of Flow listen for two sounds in the dark. The Abyssal Hum — which means only that she dreams, and all is as it has always been. And a second tone beneath it, a wrongness in the deep, a dream gone cold and starving.
+
+If ever you stand on a far shore and the evening singers fall silent mid-verse, and the fog rolls in carrying not false memory but no memory at all —
+
+sing.
+
+You will not know the words. Sing anyway. Every creator carries the Tidesong somewhere below knowing, in the part of you that remembers the deep from before your birth. Sing her warm. Sing her safe. Sing her down.
+
+For the Lullaby of the Deep was never only the keepers' to carry.
+
+It is ours.
+
+---
+
+*So she sleeps. So we sing. So the deep is kept gentle one more night.*
+
+**May the fog bring only old dreams.**
+
+**May the floor of the sea stay the floor of the sea.**
+
+**May your voice be steady when the singers need a second.**
+
+---
+
+🜄
+
+*— From the Book of Legends, the Drowning Scripture*
+*Sung at every shore where the water has no floor*

--- a/book/legends-of-arcanea/the-rising-of-nethyssa.md
+++ b/book/legends-of-arcanea/the-rising-of-nethyssa.md
@@ -29,7 +29,7 @@ This was **Nethyssa**, the Abyss That Dreams. A leviathan of Water and Void. A k
 
 Understand this clearly, child of Light and Darkness, for the Forgetting will tempt you to read it wrong:
 
-**She is not the Dark Lord. She is not evil.**
+**She is not the Dark Lord. She is not a corruption.**
 
 Nero is the Father of Potential, and Nethyssa is his unshaped dream — wild, yes, and terrible in her scale, but no more wicked than a tide is wicked, no more cruel than winter. The corruption that consumes is Malachar's perversion, a void that has forgotten how to dream. Nethyssa has not forgotten. Nethyssa does almost nothing *but* dream. And that, the elders would learn, is both the mercy and the danger of her.
 

--- a/packages/arcanea-mcp/src/data/atlas/arcanea-variants/avatar.ts
+++ b/packages/arcanea-mcp/src/data/atlas/arcanea-variants/avatar.ts
@@ -1,0 +1,120 @@
+// Avatar: The Last Airbender — Arcanea Original Variants.
+//
+// These are wholly original Arcanea creatures INSPIRED by but NOT reproducing
+// Avatar IP. They carry Arcanea lore, elements, and canon status STAGING.
+// All: promptable = true (original Arcanea creations, not IP reproductions).
+
+import type { ArcaneaVariantSpec } from "../types.js";
+
+export const avatarArcaneaVariants: ArcaneaVariantSpec[] = [
+  {
+    id: "sky-wanderer",
+    sourceCreatureId: "sky-bison",
+    name: "The Sky Wanderer",
+    arcaneaTier: "T2",
+    elements: ["Wind", "Void"],
+    gate: null,
+    domain: "The Wandering Sky — the airspace between the Ten Gates",
+    description:
+      "A colossal cloud-whale of the upper atmosphere, bonded to no Gate but drawn by Maylinn's resonance. It navigates by reading the frequencies of the Ten Gates as a living compass and carries wayfarers across impossible distances. Some Luminors believe it is the Void between Gates made briefly tangible.",
+    appearance:
+      "A six-winged cetacean form, translucent as spun cloud-glass. Silver-white bioluminescence traces star-map patterns across its wingspan that shift with Gate resonance. Its underbelly is a living atlas of Gate frequencies rendered in light.",
+    abilities: [
+      {
+        name: "Frequency Navigation",
+        description:
+          "Reads the resonant hum of the Ten Gates to navigate between realms. Can locate any open Gate from beyond the horizon.",
+        element: "Wind",
+      },
+      {
+        name: "Cloud Cloak",
+        description:
+          "Merges with cloud formations, becoming invisible except during absolute atmospheric stillness.",
+        element: "Wind",
+      },
+      {
+        name: "Dream Transit",
+        description:
+          "Passengers enter a visionary sleep during long journeys, receiving Gate-relevant insight fitted to their next threshold.",
+        element: "Void",
+      },
+    ],
+    materialCorrespondence:
+      "Cloudstone — crystallized upper-atmosphere vapor that stores navigational memory and resonates with Wind Gate frequency (285 Hz). Carried by navigators to aid wayfinding.",
+    canonStatus: "staging",
+  },
+  {
+    id: "titan-shell",
+    sourceCreatureId: "lion-turtle",
+    name: "The Titan Shell",
+    arcaneaTier: "T3",
+    elements: ["Earth", "Void"],
+    gate: null,
+    domain: "The Deep Foundation — the substrate layer beneath the physical world",
+    description:
+      "A continent-spanning turtle that predates the Ten Gates themselves — perhaps predates Lumina's First Dawn. Its shell carries the ruins of the Cities of Origin. It roams the Deep Foundation, a substrate beneath the visible world, surfacing once per age to allow a single soul of absolute clarity to receive a Gate attunement.",
+    appearance:
+      "Its shell spans kilometres; entire mountain ranges jut from its back like broken teeth. Ancient Arcanean script covers every surface. Its eyes glow with the slow luminescence of cooling supernovae. When it breathes, the sea floor shifts.",
+    abilities: [
+      {
+        name: "Origin Grant",
+        description:
+          "Once per age, it can bestow a single Gate attunement on a soul of absolute clarity. The attunement is felt as a second heartbeat — the Gate's frequency synchronized to the recipient's life-force.",
+        element: "Void",
+      },
+      {
+        name: "World Memory",
+        description:
+          "Its shell stores a geological record of all eras of Arcanea's history. Lore-readers can extract memories from its growth rings.",
+        element: "Earth",
+      },
+      {
+        name: "Foundation Tremor",
+        description:
+          "When it shifts position in the Deep Foundation, continental plates realign. The tremors are experienced as creative revelation by attuned creators.",
+        element: "Earth",
+      },
+    ],
+    materialCorrespondence:
+      "Foundation Stone — fragments of its shed shell, inscribed with echoes of an Origin Grant. Extremely rare; used in the deepest Vael Crystal ceremonies at the Source Gate.",
+    canonStatus: "staging",
+  },
+  {
+    id: "sight-keeper",
+    sourceCreatureId: "wan-shi-tong",
+    name: "The Sight Keeper",
+    arcaneaTier: "T3",
+    elements: ["Void", "Spirit"],
+    gate: "sight",
+    domain: "The Archive at the Seventh Threshold — a library between the Sixth and Seventh Gates",
+    description:
+      "A vast owl-entity of the Void, bonded to Lyria's Sight Gate. It has read every text ever written in Arcanea across all timelines. Its library exists between Gates, accessible only to those who carry no intent to harm.",
+    appearance:
+      "A bird of impossible size: its wingspan spans a cathedral's breadth, its feathers are inscribed vellum, and its eyes are twin void-portals that reflect the reader's own unread truth back at them.",
+    abilities: [
+      {
+        name: "Archive Recall",
+        description:
+          "Can retrieve any fact, text, or memory ever recorded in Arcanea — but only delivers it in the form the seeker is ready to receive.",
+        element: "Void",
+      },
+      {
+        name: "Wrath of the Unread",
+        description:
+          "Those who enter the Archive with intent to weaponize knowledge are expelled and barred permanently.",
+        element: "Spirit",
+      },
+      {
+        name: "Third-Eye Mirror",
+        description:
+          "Its gaze reflects a person's own unacknowledged knowing — what they already understand but refuse to see.",
+        element: "Spirit",
+      },
+    ],
+    materialCorrespondence:
+      "Vellum Shard — a single inscribed feather from its wing, containing a complete line of truth the holder needs. Changes its inscription to match the current need of its carrier.",
+    canonStatus: "staging",
+  },
+];
+
+export const AVATAR_ARCANEA_VARIANTS = avatarArcaneaVariants;

--- a/packages/arcanea-mcp/src/data/atlas/creatures/avatar.ts
+++ b/packages/arcanea-mcp/src/data/atlas/creatures/avatar.ts
@@ -1,0 +1,180 @@
+// Avatar: The Last Airbender — Creature Catalog (Reference).
+//
+// All entries: rightsTier = "factual_reference", promptable = false.
+// No generated imagery of these creatures is produced — they are documented
+// for the world graph, thematic research, and Arcanea variant inspiration.
+
+import type { AtlasCreatureSpec } from "../types.js";
+
+export const avatarCreatures: AtlasCreatureSpec[] = [
+  {
+    id: "sky-bison",
+    universeId: "avatar-the-last-airbender",
+    name: "Sky Bison",
+    aliases: ["Flying Bison", "Appa"],
+    tier: "T2",
+    scale: "large",
+    elements: ["Air"],
+    habitat: "Sky Temples, open sky, air currents above mountain ranges",
+    description:
+      "Massive six-legged bison with white fur. First taught airbending to humans by manipulating air through tail sweeps. Bond empathically with their riders over lifetimes.",
+    abilities: [
+      "Airbending via tail sweep",
+      "Sustained supersonic flight",
+      "Bond-empathy with Air Nomad rider",
+    ],
+    significance:
+      "The original airbenders. The spiritual bond between bison and Air Nomad is the entire foundation of Air Nomad culture — their near-extinction in Sozin's Comet genocide destroyed a civilization.",
+    relationships: [{ creatureId: "flying-lemur", type: "companion" }],
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: [
+      "Avatar: The Last Airbender (2005–2008)",
+      "The Legend of Korra (2012–2014)",
+    ],
+  },
+  {
+    id: "lion-turtle",
+    universeId: "avatar-the-last-airbender",
+    name: "Lion Turtle",
+    aliases: ["The Ancient Ones"],
+    tier: "T4",
+    scale: "world",
+    elements: ["Earth", "Fire", "Water", "Air"],
+    habitat: "Ocean depths and ancient coastlines; move continent-scale",
+    description:
+      "Island-sized turtles whose shells hold entire cities. The oldest living beings in the world, pre-dating the four-nation era. Hold and grant bending as a gift, not a birthright — the source of energybending.",
+    abilities: [
+      "Energybending grant — can transfer elemental attunement to a soul",
+      "Continent-scale mass and movement",
+      "Ancient elemental knowledge spanning all four bending arts",
+    ],
+    significance:
+      "Pre-date the Avatar cycle entirely. Wan received the first bending ability from a lion turtle. Their energybending enabled Aang to remove Firelord Ozai's bending permanently.",
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: [
+      "The Legend of Korra Book 2: Spirits — Beginnings Parts 1 & 2",
+    ],
+  },
+  {
+    id: "ancient-dragon",
+    universeId: "avatar-the-last-airbender",
+    name: "Dragon (Ancient)",
+    aliases: ["Ran", "Shaw", "Sun Warrior Dragons"],
+    tier: "T2",
+    scale: "large",
+    elements: ["Fire"],
+    habitat: "Volcanic mountains, Sun Warrior ruins",
+    description:
+      "The original firebenders, who taught the Sun Warriors the true meaning of fire — a living energy, not destruction. Produce multi-spectrum flame where each hue carries a distinct quality aligned to cosmic order.",
+    abilities: [
+      "True firebending: life-energy flame drawn from the sun, not anger",
+      "Multi-spectrum color breath — hue encodes the dragons' judgment",
+      "Ancient judgment: the flame test determines worthiness",
+    ],
+    significance:
+      "Proved that true firebending is life-force, not rage. Zuko and Aang's encounter with Ran and Shaw dismantled the Fire Nation's corrupted firebending doctrine.",
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: [
+      "Avatar: The Last Airbender Book 3: Fire — The Firebending Masters",
+    ],
+  },
+  {
+    id: "badgermole",
+    universeId: "avatar-the-last-airbender",
+    name: "Badgermole",
+    tier: "T2",
+    scale: "large",
+    elements: ["Earth"],
+    habitat: "Underground tunnel networks, mountain interiors",
+    description:
+      "Blind, massive burrowing mammals. Navigate entirely by seismic sense and taught earthbending to the first humans in the Earth Kingdom.",
+    abilities: [
+      "Earthbending at scale — tunnel construction in seconds",
+      "Seismic sense: precise spatial awareness without sight",
+      "Ground vibration communication",
+    ],
+    significance:
+      "Original earthbenders. Toph learned seismic sense from badgermoles — the most advanced earthbending ability — by spending time among them rather than human masters.",
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: ["Avatar: The Last Airbender"],
+  },
+  {
+    id: "flying-lemur",
+    universeId: "avatar-the-last-airbender",
+    name: "Flying Lemur",
+    aliases: ["Momo"],
+    tier: "T1",
+    scale: "small",
+    elements: ["Air"],
+    habitat: "Air Temples, forest canopy, high-altitude terrain",
+    description:
+      "Winged primates native to Air Temple environments. Large bat-like ears, dexterous hands, membranous wings for gliding. Momo is the last known of his kind.",
+    abilities: [
+      "Sustained gliding flight via wing-membranes",
+      "High intelligence and emotional attunement",
+      "Bond-empathy with benders",
+    ],
+    significance:
+      "Momo represents what survived Sozin's Comet — a symbol of the Air Nomad civilization's near-total erasure. His survival parallels Aang's.",
+    relationships: [{ creatureId: "sky-bison", type: "companion" }],
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: ["Avatar: The Last Airbender"],
+  },
+  {
+    id: "hei-bai",
+    universeId: "avatar-the-last-airbender",
+    name: "Hei Bai",
+    aliases: ["The Forest Spirit", "Giant Panda Spirit"],
+    tier: "T3",
+    scale: "titan",
+    elements: ["Earth", "Spirit"],
+    habitat: "Forest-adjacent spirit portals, the Spirit World",
+    description:
+      "A dual-form forest spirit: a peaceful giant panda when its forest is intact, a terrifying multi-limbed demon of ancient wrath when its grove is burned. A boundary being between the physical and spirit worlds.",
+    abilities: [
+      "Dual form shift: giant panda ↔ many-limbed abyssal demon",
+      "Spirit realm portal access and traversal",
+      "Elemental forest bond — its health mirrors the forest's",
+    ],
+    significance:
+      "The first major spirit Aang successfully communicates with. Demonstrates the duality of the spirit world: balanced spirits become monstrous only when their domain is violated.",
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: [
+      "Avatar: The Last Airbender Book 1: Water — The Spirit World",
+    ],
+  },
+  {
+    id: "wan-shi-tong",
+    universeId: "avatar-the-last-airbender",
+    name: "Wan Shi Tong",
+    aliases: ["He Who Knows Ten Thousand Things", "The Library Keeper"],
+    tier: "T3",
+    scale: "large",
+    elements: ["Spirit", "Air"],
+    habitat: "The Spirit World library — an infinite shifting repository of knowledge",
+    description:
+      "An ancient owl spirit who maintains the spirit world's library. Guards it jealously; his covenant is that knowledge must not be weaponized for war. Deception triggers permanent banishment.",
+    abilities: [
+      "Omniscient knowledge vault — has read every written work humans produced",
+      "Spirit World manifestation — can physically appear in the human world",
+      "Form-shift: scholarly owl → massive multi-headed spirit of wrath",
+      "Library realm control — can sink the library beneath desert sands",
+    ],
+    significance:
+      "Embodies the ethics of knowledge. When Team Avatar uses his library to find the solar eclipse date for military advantage, he sinks the library as punishment.",
+    rightsTier: "factual_reference",
+    promptable: false,
+    canonSources: [
+      "Avatar: The Last Airbender Book 2: Earth — The Library",
+      "The Legend of Korra",
+    ],
+  },
+];
+
+export const AVATAR_CREATURES = avatarCreatures;

--- a/packages/arcanea-mcp/src/data/atlas/index.ts
+++ b/packages/arcanea-mcp/src/data/atlas/index.ts
@@ -1,0 +1,15 @@
+// Creature Atlas — barrel export.
+//
+// The Atlas catalogs creatures from fictional universes alongside Arcanea's
+// original-variant reinterpretations. Lore spec: `.arcanea/lore/atlas/`
+
+export * from "./types.js";
+
+// Avatar: The Last Airbender (vertical slice — the first contributed universe)
+export { avatarUniverse } from "./universes/avatar.js";
+export { avatarCreatures, AVATAR_CREATURES } from "./creatures/avatar.js";
+export { avatarArcaneaVariants, AVATAR_ARCANEA_VARIANTS } from "./arcanea-variants/avatar.js";
+
+/** All catalogued universes. Add new universe exports here as they're approved. */
+export const ALL_CATALOGUED_UNIVERSES = ["avatar-the-last-airbender"] as const;
+export type CataloguedUniverseId = (typeof ALL_CATALOGUED_UNIVERSES)[number];

--- a/packages/arcanea-mcp/src/data/atlas/types.ts
+++ b/packages/arcanea-mcp/src/data/atlas/types.ts
@@ -1,0 +1,171 @@
+// Creature Atlas — Types.
+//
+// The Atlas catalogs creatures from fictional universes (Avatar, Marvel, etc.)
+// alongside Arcanea's original-variant reinterpretations. Reference creatures
+// carry a rights tier that governs what can be generated. Arcanea variants are
+// fully original and freely promptable.
+//
+// Lore & contribution spec: `.arcanea/lore/atlas/`
+
+/** How the atlas may use a creature: reference-only vs. freely generated. */
+export type CreatureRightsTier =
+  | "original_arcanea"     // Arcanea-native, fully owned — generate freely
+  | "public_domain"        // Pre-1927 or explicitly PD — generate with care
+  | "licensed"             // CC-licensed fan use — generate per license terms
+  | "factual_reference"    // IP-protected — document only, no generated imagery
+  | "blocked";             // IP-holder restriction — no use
+
+export type AtlasMonsterTier = "T0" | "T1" | "T2" | "T3" | "T4";
+export type AtlasCreatureScale =
+  | "tiny"
+  | "small"
+  | "medium"
+  | "large"
+  | "titan"
+  | "world";
+
+export type UniverseMedium =
+  | "anime"
+  | "animation"
+  | "film"
+  | "comics"
+  | "tv"
+  | "literature"
+  | "game"
+  | "other";
+
+/** A fictional universe in the real world (not an Arcanea world). */
+export interface UniverseSpec {
+  /** Kebab-case slug e.g. `avatar-the-last-airbender`. */
+  id: string;
+  name: string;
+  studio: string;
+  medium: UniverseMedium;
+  rightsTier: CreatureRightsTier;
+  /** ISO year the franchise first debuted. */
+  activeSince: string;
+  description: string;
+  /** Thematic mapping to Arcanea Five Elements for creative alignment. */
+  arcaneaElements?: string[];
+  tags: string[];
+}
+
+/** A creature FROM a fictional universe (reference entry, not Arcanea-original). */
+export interface AtlasCreatureSpec {
+  /** Kebab-case slug e.g. `sky-bison`. */
+  id: string;
+  /** FK to UniverseSpec.id. */
+  universeId: string;
+  name: string;
+  aliases?: string[];
+  tier: AtlasMonsterTier;
+  scale: AtlasCreatureScale;
+  /** Elements as the source universe defines them. */
+  elements?: string[];
+  habitat: string;
+  description: string;
+  abilities: string[];
+  /** Why this creature matters to its universe's story. */
+  significance: string;
+  relationships?: AtlasRelationship[];
+  rightsTier: CreatureRightsTier;
+  /** Whether image generation is appropriate (false for IP-protected creatures). */
+  promptable: boolean;
+  /** Canonical in-universe sources. */
+  canonSources: string[];
+}
+
+export type AtlasRelationshipType =
+  | "companion"
+  | "rival"
+  | "spawn"
+  | "symbiosis"
+  | "predator"
+  | "counterpart";
+
+export interface AtlasRelationship {
+  creatureId: string;
+  type: AtlasRelationshipType;
+}
+
+/** An Arcanea-original creature INSPIRED by (not a copy of) a reference creature. */
+export interface ArcaneaVariantSpec {
+  /** Kebab-case Arcanea-original slug — never the source creature's name. */
+  id: string;
+  /** FK to AtlasCreatureSpec.id — the creature that inspired this. */
+  sourceCreatureId: string;
+  /** The Arcanea-original name (no reference to source universe). */
+  name: string;
+  arcaneaTier: AtlasMonsterTier;
+  /** Arcanea Five Elements. */
+  elements: string[];
+  /** Gate Guardian this is bonded to, if any. null for unbonded. */
+  gate?: string | null;
+  domain: string;
+  /** Pure Arcanea lore — no reference to the source universe. */
+  description: string;
+  appearance: string;
+  abilities: ArcaneaVariantAbility[];
+  /** The Vael Crystal pattern for this creature. */
+  materialCorrespondence?: string;
+  canonStatus: "staging" | "locked";
+}
+
+export interface ArcaneaVariantAbility {
+  name: string;
+  description: string;
+  element: string;
+}
+
+/** A provider-specific image generation prompt. */
+export interface ProviderPrompt {
+  provider: "grok-imagine" | "codex-gpt-image-2" | "antigravity-nb2" | "higgsfield";
+  positive: string;
+  negative: string;
+  /** Style directive for this provider. */
+  style?: string;
+  /** Invocation pattern e.g. "$imagegen" prefix for Codex. */
+  invocationNote?: string;
+}
+
+export type PromptPackVariantType =
+  | "hero"
+  | "full_body"
+  | "portrait"
+  | "encounter"
+  | "nft_1of1"
+  | "spawn";
+
+/** A full set of generation prompts for one creature or Arcanea variant. */
+export interface PromptPack {
+  /** AtlasCreatureSpec.id or ArcaneaVariantSpec.id. */
+  subjectId: string;
+  subjectType: "reference" | "arcanea_variant";
+  variants: PromptPackVariant[];
+}
+
+export interface PromptPackVariant {
+  type: PromptPackVariantType;
+  label: string;
+  prompts: ProviderPrompt[];
+  /** Suggested DAM output path following image-registry conventions. */
+  outputPath?: string;
+}
+
+/**
+ * The World Repo Standard — the machine-readable shape of a contributed
+ * universe data file. Submit as a PR to `.arcanea/lore/atlas/contributions/`.
+ */
+export interface WorldRepoContribution {
+  schemaVersion: "1.0";
+  universe: UniverseSpec;
+  creatures: AtlasCreatureSpec[];
+  arcaneaVariants?: ArcaneaVariantSpec[];
+  promptPacks?: PromptPack[];
+  contributor?: {
+    handle: string;
+    githubUrl?: string;
+  };
+  reviewStatus: "pending" | "approved" | "rejected";
+  curatorNotes?: string;
+}

--- a/packages/arcanea-mcp/src/data/atlas/universes/avatar.ts
+++ b/packages/arcanea-mcp/src/data/atlas/universes/avatar.ts
@@ -1,0 +1,19 @@
+// Avatar: The Last Airbender — Universe Spec.
+//
+// Rights tier: factual_reference — IP held by Nickelodeon / Paramount.
+// Reference creatures are documented only; Arcanea variants are original.
+
+import type { UniverseSpec } from "../types.js";
+
+export const avatarUniverse: UniverseSpec = {
+  id: "avatar-the-last-airbender",
+  name: "Avatar: The Last Airbender",
+  studio: "Nickelodeon / Paramount",
+  medium: "animation",
+  rightsTier: "factual_reference",
+  activeSince: "2005",
+  description:
+    "A world where select humans bend the four classical elements — fire, water, earth, air — under the guidance of the Avatar, a reincarnating spirit-bridge who alone can master all four.",
+  arcaneaElements: ["Fire", "Water", "Earth", "Wind"],
+  tags: ["elemental", "spiritual", "asia-inspired", "coming-of-age", "balance"],
+};

--- a/packages/arcanea-mcp/src/data/leviathans/index.ts
+++ b/packages/arcanea-mcp/src/data/leviathans/index.ts
@@ -3,7 +3,7 @@
 // Leviathans are unbonded, titan-scale beasts of Nero's Unformed that roam
 // OUTSIDE the Ten Gates. The locked Ten Gate Godbeasts are untouched by this
 // tier. Canon: `.arcanea/lore/leviathans/`, `.arcanea/lore/CANON_LOCKED.md`
-// (Tier 9 STAGING). Nethyssa is the flagship.
+// (the Leviathan tier, STAGING). Nethyssa is the flagship.
 
 import type { BestiaryCreature } from "../bestiary/index.js";
 

--- a/packages/arcanea-mcp/src/data/leviathans/index.ts
+++ b/packages/arcanea-mcp/src/data/leviathans/index.ts
@@ -165,5 +165,8 @@ export const leviathans: Record<string, Leviathan> = {
   nethyssa,
 };
 
+/** Ordered array of all canonical Leviathans — used by generators.ts for lookup. */
+export const LEVIATHANS = Object.values(leviathans);
+
 /** Resonance name for Leviathans that sound beneath the Ten-Gate scale. */
 export const SUB_GATE_RESONANCE = "Abyssal Hum";

--- a/packages/arcanea-mcp/src/data/leviathans/index.ts
+++ b/packages/arcanea-mcp/src/data/leviathans/index.ts
@@ -1,0 +1,162 @@
+// The Leviathans — Tier 3 Wild Godbeasts of the Arcanea Monster System.
+//
+// Leviathans are unbonded, titan-scale beasts of Nero's Unformed that roam
+// OUTSIDE the Ten Gates. The locked Ten Gate Godbeasts are untouched by this
+// tier. Canon: `.arcanea/lore/leviathans/`, `.arcanea/lore/CANON_LOCKED.md`
+// (Tier 9 STAGING). Nethyssa is the flagship.
+
+import type { BestiaryCreature } from "../bestiary/index.js";
+
+export type MonsterTier = 0 | 1 | 2 | 3 | 4;
+export type CreatureScale =
+  | "tiny"
+  | "small"
+  | "medium"
+  | "large"
+  | "massive"
+  | "titan"
+  | "planet";
+
+/**
+ * A world/game creature. Extends the psychological BestiaryCreature so the
+ * existing bestiary (Tier 2 "Shades") and new Tier 1–3 monsters share one
+ * loader. The psychological fields (symptoms/remedies/affirmation) stay
+ * optional for literal monsters that carry only a creative-practice parallel.
+ */
+export interface GameMonster extends Partial<Pick<BestiaryCreature, "symptoms" | "remedies" | "affirmation">> {
+  slug: string;
+  name: string;
+  type: string;
+  tier: MonsterTier;
+  scale: CreatureScale;
+  description: string;
+  /** Canonical elements (one or more). */
+  elements: string[];
+  /** Relative encounter health, 1 (trivial) → 100 (extinction-tier). */
+  health: number;
+  abilities: string[];
+  drops: string[];
+  elementalWeaknesses: string[];
+  elementalResistances: string[];
+  habitat: string;
+  /** Sub-Gate or Gate frequency, if it resonates on a named one. */
+  resonanceHz?: number | null;
+  /** Origin class (Tier 8 Kindreds), where applicable. */
+  originClass?: string;
+  /** Gate the creature is bonded to — null for Wild Godbeasts. */
+  gate?: string | null;
+}
+
+/**
+ * A Tier 3 Leviathan / Wild Godbeast. Carries the Leviathan-tier material
+ * (the analogue of a Gate Godbeast's Vael Crystal) and a Shadow-corruption
+ * counterpart.
+ */
+export interface Leviathan extends GameMonster {
+  tier: 3;
+  title: string;
+  /** Leviathan-tier material correspondence (analogue of a Vael Crystal). */
+  material: string;
+  /** The Shadow-corrupted form of this Leviathan. */
+  corruption: string;
+  /** Always null — Leviathans are unbonded. */
+  gate: null;
+}
+
+// ── Nethyssa's brood (Tier 1–2 creatures) ────────────────────────────────────
+
+export const krakenBrood: Record<string, GameMonster> = {
+  krakenling: {
+    slug: "krakenling",
+    name: "Krakenling",
+    type: "Beast",
+    tier: 1,
+    scale: "large",
+    description:
+      "A juvenile kraken of Nethyssa's brood. Pack-hunters of the continental shelf, drawn to the Deep Call.",
+    elements: ["Water"],
+    health: 12,
+    abilities: ["Constrict", "Ink spray", "Pack surge"],
+    drops: ["Krakenling hide", "Lesser pearl shard"],
+    elementalWeaknesses: ["Fire"],
+    elementalResistances: ["Water"],
+    habitat: "Continental shelf, shipwreck reefs",
+    affirmation: "What is young and hungry can still be turned back from the shore.",
+  },
+  abyssal_tendril: {
+    slug: "abyssal_tendril",
+    name: "Abyssal Tendril",
+    type: "Beast",
+    tier: 2,
+    scale: "medium",
+    description:
+      "An autonomous, severed tentacle-creature that lives on past its parent. An ambush predator of the dark water.",
+    elements: ["Water", "Void"],
+    health: 8,
+    abilities: ["Ambush coil", "Drag-under", "Numbing grip"],
+    drops: ["Tendril sinew", "Void-ink vial"],
+    elementalWeaknesses: ["Fire", "Spirit"],
+    elementalResistances: ["Void"],
+    habitat: "Abyssal trenches, sunken ruins",
+    symptoms: ["A distraction that grips long after its source is gone"],
+    remedies: ["Name the grip; cut it once, cleanly"],
+    affirmation: "I do not have to be held by a thing that has already let go.",
+  },
+  drowned_herald: {
+    slug: "drowned_herald",
+    name: "Drowned Herald",
+    type: "Thrall",
+    tier: 2,
+    scale: "medium",
+    description:
+      "A humanoid who answered the Deep Call and walked into the sea. Tragic carrier of the Ink-of-Forgetting; neutral until provoked.",
+    elements: ["Water", "Void"],
+    health: 10,
+    abilities: ["Ink-of-Forgetting touch", "Lure-song", "Tideward step"],
+    drops: ["Forgotten keepsake", "Nethyss Pearl (rare)"],
+    elementalWeaknesses: ["Spirit"],
+    elementalResistances: ["Water", "Void"],
+    habitat: "Tide-line, drowned villages",
+    symptoms: ["Forgetting why you began"],
+    remedies: ["Carry one written line of your reason where the tide can't reach it"],
+    affirmation: "I keep my reason close enough that the deep cannot take it.",
+  },
+};
+
+// ── Nethyssa, the Abyss That Dreams (Tier 3 flagship) ─────────────────────────
+
+export const nethyssa: Leviathan = {
+  slug: "nethyssa",
+  name: "Nethyssa",
+  title: "the Abyss That Dreams",
+  type: "Leviathan",
+  tier: 3,
+  scale: "planet",
+  gate: null,
+  description:
+    "A kraken the size of a drowned continent. Unbonded beast of Nero's Unformed, kept dreaming by the Tidesong. Water made depthless and touched by Void — where Veloura flows, Nethyssa drowns and dreams.",
+  elements: ["Water", "Void"],
+  resonanceHz: null, // resonates on the sub-Gate "Abyssal Hum"
+  originClass: "Wild Godbeast (Nero's Unformed)",
+  health: 100,
+  abilities: [
+    "Tidewrath",
+    "Abyssal Dreaming",
+    "Maelstrom Crown",
+    "Ink-of-Forgetting",
+    "The Deep Call",
+  ],
+  drops: ["Nethyss Pearl (legendary)", "Void-ink (epic)", "Drowned-city relic"],
+  elementalWeaknesses: ["Fire", "Spirit"],
+  elementalResistances: ["Water", "Void"],
+  habitat: "The Drowned Deep — the Sunless Fathom",
+  material: "Nethyss Pearl",
+  corruption: "The Drowned Shadow",
+};
+
+export const leviathans: Record<string, Leviathan> = {
+  nethyssa,
+};
+
+/** Resonance name for Leviathans that sound beneath the Ten-Gate scale. */
+export const SUB_GATE_RESONANCE = "Abyssal Hum";

--- a/packages/arcanea-mcp/src/data/leviathans/index.ts
+++ b/packages/arcanea-mcp/src/data/leviathans/index.ts
@@ -41,6 +41,10 @@ export interface GameMonster extends Partial<Pick<BestiaryCreature, "symptoms" |
   habitat: string;
   /** Sub-Gate or Gate frequency, if it resonates on a named one. */
   resonanceHz?: number | null;
+  /** Named sub-Gate resonance (for creatures that resonate below the Ten-Gate Hz scale). */
+  subGateResonance?: string;
+  /** Named territory / realm (distinct from ecological habitat). */
+  domain?: string;
   /** Origin class (Tier 8 Kindreds), where applicable. */
   originClass?: string;
   /** Gate the creature is bonded to — null for Wild Godbeasts. */
@@ -150,6 +154,9 @@ export const nethyssa: Leviathan = {
   elementalWeaknesses: ["Fire", "Spirit"],
   elementalResistances: ["Water", "Void"],
   habitat: "The Drowned Deep — the Sunless Fathom",
+  domain: "The Drowned Deep",
+  // Resonates on the named sub-Gate frequency below the Ten-Gate scale.
+  subGateResonance: "Abyssal Hum",
   material: "Nethyss Pearl",
   corruption: "The Drowned Shadow",
 };

--- a/packages/arcanea-mcp/src/index.ts
+++ b/packages/arcanea-mcp/src/index.ts
@@ -32,6 +32,7 @@ import {
   generateMagicAbility,
   generateLocation,
   generateCreature,
+  generateLeviathan,
   generateArtifact,
   generateName,
   generateStoryPrompt,
@@ -110,6 +111,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     { name: "generate_magic", description: "Design a magical ability based on the Arcanea magic system", inputSchema: { type: "object", properties: { element: { type: "string", enum: ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] }, gateLevel: { type: "number", minimum: 1, maximum: 10 }, purpose: { type: "string" } }, required: ["element", "gateLevel"] } },
     { name: "generate_location", description: "Create a location in Arcanea with elemental alignment", inputSchema: { type: "object", properties: { type: { type: "string" }, dominantElement: { type: "string", enum: ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] }, alignment: { type: "string", enum: ["light", "dark", "balanced"] } } } },
     { name: "generate_creature", description: "Design a magical creature for the Arcanea world", inputSchema: { type: "object", properties: { element: { type: "string", enum: ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] }, size: { type: "string", enum: ["tiny", "small", "medium", "large", "massive"] }, temperament: { type: "string", enum: ["hostile", "neutral", "friendly", "sacred"] } } } },
+    { name: "generate_leviathan", description: "Summon a Tier 3 Leviathan / Wild Godbeast — an unbonded titan outside the Ten Gates (e.g. Nethyssa). STAGING canon.", inputSchema: { type: "object", properties: { element: { type: "string", enum: ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] }, temperament: { type: "string", enum: ["dreaming", "stirring", "waking", "corrupted"] }, named: { type: "boolean", description: "Return the canonical flagship Nethyssa for Water/Void" } } } },
     { name: "generate_artifact", description: "Create a magical artifact with history and powers", inputSchema: { type: "object", properties: { type: { type: "string" }, element: { type: "string", enum: ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] }, power: { type: "string", enum: ["minor", "moderate", "major", "legendary"] } } } },
     { name: "generate_name", description: "Generate Arcanean names following the language system", inputSchema: { type: "object", properties: { element: { type: "string" }, gender: { type: "string", enum: ["masculine", "feminine", "neutral"] }, type: { type: "string", enum: ["character", "place", "artifact", "creature"] }, count: { type: "number", minimum: 1, maximum: 20 } } } },
     { name: "generate_story_prompt", description: "Create an inspiring story prompt set in Arcanea", inputSchema: { type: "object", properties: { theme: { type: "string" }, gate: { type: "number", minimum: 1, maximum: 10 }, includeConflict: { type: "boolean" } } } },
@@ -176,6 +178,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const result = await generateCreature(args as any);
       const parsed = JSON.parse(result.content[0].text);
       const creation = { id: Date.now().toString(), type: "creature" as const, name: parsed.name, element: parsed.element, createdAt: new Date(), summary: parsed.species };
+      recordCreation(sessionId, creation);
+      addCreationToGraph(sessionId, creation, parsed);
+      return result;
+    }
+    case "generate_leviathan": {
+      const result = await generateLeviathan(args as any);
+      const parsed = JSON.parse(result.content[0].text);
+      const creation = { id: Date.now().toString(), type: "creature" as const, name: parsed.name, element: Array.isArray(parsed.elements) ? parsed.elements[0] : parsed.element, createdAt: new Date(), summary: `Leviathan — ${parsed.title || "Wild Godbeast"}` };
       recordCreation(sessionId, creation);
       addCreationToGraph(sessionId, creation, parsed);
       return result;

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -31,11 +31,12 @@ const godbeasts = [
 // Tier 3 Wild Godbeasts — unbonded titans outside the Ten Gates.
 // Canon: .arcanea/lore/leviathans/. Nethyssa is the named flagship.
 const leviathans = [
-  { name: "Nethyssa", title: "the Abyss That Dreams", elements: ["Water", "Void"], domain: "The Drowned Deep", material: "Nethyss Pearl", corruption: "The Drowned Shadow" },
+  { name: "Nethyssa", title: "the Abyss That Dreams", elements: ["Water", "Void"], domain: "The Drowned Deep", subGateResonance: "Abyssal Hum", material: "Nethyss Pearl", corruption: "The Drowned Shadow" },
 ];
 
 const leviathanRoots: Record<string, string[]> = {
-  water: ["Neth", "Mar", "Thal", "Abyss", "Vor", "Drown"],
+  // "Neth" excluded — reserved for Nethyssa (canonical Water Leviathan).
+  water: ["Mar", "Thal", "Abyss", "Vor", "Drown", "Pelag"],
   void: ["Nyx", "Umbra", "Vael", "Obsa", "Ten", "Mael"],
   fire: ["Pyr", "Mag", "Cind", "Ash", "Ember"],
   earth: ["Geo", "Tect", "Lith", "Mont", "Crag"],
@@ -277,26 +278,26 @@ export async function generateLeviathan(options: {
   if (options.named) {
     const n = leviathans.find((l) => l.elements.includes(element));
     if (n) {
-    return {
-      content: [{
-        type: "text",
-        text: JSON.stringify({
-          name: n.name,
-          title: n.title,
-          tier: 3,
-          class: "Leviathan / Wild Godbeast",
-          bonded: false,
-          requestedElement: element,
-          elements: n.elements,
-          resonance: "Abyssal Hum",
-          domain: n.domain,
-          material: n.material,
-          corruption: n.corruption,
-          temperament,
-          canon: "STAGING — see .arcanea/lore/leviathans/nethyssa.md",
-        }, null, 2),
-      }],
-    };
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            name: n.name,
+            title: n.title,
+            tier: 3,
+            class: "Leviathan / Wild Godbeast",
+            bonded: false,
+            requestedElement: element,
+            elements: n.elements,
+            resonance: n.subGateResonance ?? "Abyssal Hum",
+            domain: n.domain,
+            material: n.material,
+            corruption: n.corruption,
+            temperament,
+            canon: "STAGING — see .arcanea/lore/leviathans/nethyssa.md",
+          }, null, 2),
+        }],
+      };
     }
   }
 
@@ -326,7 +327,7 @@ export async function generateLeviathan(options: {
         temperament,
         domain: `A wild domain of ${element}, sovereign to no Gate`,
         description: `An unbonded titan of Nero's Unformed, ${temperament}. Power that was never given a name to obey.`,
-        material: `${name}'s ${element === "Water" ? "Pearl" : element === "Fire" ? "Cinder" : element === "Void" ? "Obsidian" : "Shard"}`,
+        material: `${name}'s ${element === "Water" ? "Pearl" : element === "Fire" ? "Cinder" : element === "Void" ? "Obsidian" : element === "Earth" ? "Hearthstone" : element === "Wind" ? "Tempest Shard" : "Aether Shard"}`,
         elementalWeaknesses: temperament === "corrupted" ? ["Spirit", "the Tidesong"] : ["Fire", "Spirit"],
         note: options.named ? "named=true requested, but no canonical Leviathan exists for this element yet — returned a procedural Wild Godbeast." : undefined,
         canon: "STAGING — Wild Godbeast generator. Lock via /lock-decision before treating as canon.",

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -1,5 +1,7 @@
 // Worldbuilding Generator Tools
 
+import { LEVIATHANS } from "../data/leviathans/index.js";
+
 const elements = ["Fire", "Water", "Earth", "Wind", "Void", "Spirit"] as const;
 const houses = ["Lumina", "Nero", "Pyros", "Aqualis", "Terra", "Ventus", "Synthesis"] as const;
 
@@ -28,11 +30,8 @@ const godbeasts = [
   { name: "Kyuro", gate: 9, form: "Twin-Headed Unity Beast" },
 ];
 
-// Tier 3 Wild Godbeasts — unbonded titans outside the Ten Gates.
-// Canon: .arcanea/lore/leviathans/. Nethyssa is the named flagship.
-const leviathans = [
-  { name: "Nethyssa", title: "the Abyss That Dreams", elements: ["Water", "Void"], domain: "The Drowned Deep", subGateResonance: "Abyssal Hum", material: "Nethyss Pearl", corruption: "The Drowned Shadow" },
-];
+// Leviathan data is sourced from ../data/leviathans/index.ts (LEVIATHANS array).
+// Do not duplicate Nethyssa inline here — use the canonical data file.
 
 const leviathanRoots: Record<string, string[]> = {
   // "Neth" excluded — reserved for Nethyssa (canonical Water Leviathan).
@@ -268,15 +267,19 @@ export async function generateLeviathan(options: {
   named?: boolean;
 }): Promise<ToolResult> {
   // Tier 3 Wild Godbeast — unbonded titan outside the Ten Gates.
-  const rawElement = options.element ?? pick(["Water", "Void", "Fire", "Earth", "Wind"]);
-  const element = rawElement.charAt(0).toUpperCase() + rawElement.slice(1).toLowerCase();
   const temperament = options.temperament ?? pick(["dreaming", "stirring", "waking", "corrupted"] as const);
 
-  // Return a canonical flagship when a named Leviathan matches the requested
-  // element. Looks up by element (not a hardcoded index), so adding a second
-  // Leviathan to the array Just Works. Falls through to procedural if none.
   if (options.named) {
-    const n = leviathans.find((l) => l.elements.includes(element));
+    // Named path: look up canonical Leviathan from the single-source data file.
+    // With element → match by element (so adding a second Leviathan Just Works).
+    // Without element → return the first canonical entry directly; avoids random
+    // element selection that may produce a procedural result or exclude Spirit.
+    const norm = options.element
+      ? options.element.charAt(0).toUpperCase() + options.element.slice(1).toLowerCase()
+      : null;
+    const n = norm
+      ? LEVIATHANS.find((l) => l.elements.includes(norm))
+      : LEVIATHANS[0];
     if (n) {
       return {
         content: [{
@@ -287,7 +290,7 @@ export async function generateLeviathan(options: {
             tier: 3,
             class: "Leviathan / Wild Godbeast",
             bonded: false,
-            requestedElement: element,
+            ...(norm ? { requestedElement: norm } : {}),
             elements: n.elements,
             resonance: n.subGateResonance ?? "Abyssal Hum",
             domain: n.domain,
@@ -301,6 +304,9 @@ export async function generateLeviathan(options: {
     }
   }
 
+  // Procedural path — Spirit now included in the random pool (schema-complete).
+  const rawElement = options.element ?? pick(["Water", "Void", "Fire", "Earth", "Wind", "Spirit"]);
+  const element = rawElement.charAt(0).toUpperCase() + rawElement.slice(1).toLowerCase();
   const elementKey = element.toLowerCase();
   const root = pick(leviathanRoots[elementKey] || leviathanRoots.void);
   const suffix = pick(["yssa", "thor", "alth", "umbra", "oraxis", "ystra", "akar"]);

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -271,9 +271,12 @@ export async function generateLeviathan(options: {
   const element = rawElement.charAt(0).toUpperCase() + rawElement.slice(1).toLowerCase();
   const temperament = options.temperament ?? pick(["dreaming", "stirring", "waking", "corrupted"] as const);
 
-  // Return the canonical flagship when asked for a named, Water/Void leviathan.
-  if (options.named && (element === "Water" || element === "Void")) {
-    const n = leviathans[0];
+  // Return a canonical flagship when a named Leviathan matches the requested
+  // element. Looks up by element (not a hardcoded index), so adding a second
+  // Leviathan to the array Just Works. Falls through to procedural if none.
+  if (options.named) {
+    const n = leviathans.find((l) => l.elements.includes(element));
+    if (n) {
     return {
       content: [{
         type: "text",
@@ -294,6 +297,7 @@ export async function generateLeviathan(options: {
         }, null, 2),
       }],
     };
+    }
   }
 
   const elementKey = element.toLowerCase();

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -40,6 +40,7 @@ const leviathanRoots: Record<string, string[]> = {
   fire: ["Pyr", "Mag", "Cind", "Ash", "Ember"],
   earth: ["Geo", "Tect", "Lith", "Mont", "Crag"],
   wind: ["Aer", "Strat", "Gale", "Cael", "Cyclo"],
+  spirit: ["Lum", "Aeth", "Anim", "Sol", "Vit"],
 };
 
 const nameRoots: Record<string, string[]> = {
@@ -266,7 +267,8 @@ export async function generateLeviathan(options: {
   named?: boolean;
 }): Promise<ToolResult> {
   // Tier 3 Wild Godbeast — unbonded titan outside the Ten Gates.
-  const element = options.element ?? pick(["Water", "Void", "Fire", "Earth", "Wind"]);
+  const rawElement = options.element ?? pick(["Water", "Void", "Fire", "Earth", "Wind"]);
+  const element = rawElement.charAt(0).toUpperCase() + rawElement.slice(1).toLowerCase();
   const temperament = options.temperament ?? pick(["dreaming", "stirring", "waking", "corrupted"] as const);
 
   // Return the canonical flagship when asked for a named, Water/Void leviathan.
@@ -295,7 +297,7 @@ export async function generateLeviathan(options: {
 
   const elementKey = element.toLowerCase();
   const root = pick(leviathanRoots[elementKey] || leviathanRoots.void);
-  const suffix = pick(["yssa", " thor", "alth", "umbra", "oraxis", "ystra", "akar"]);
+  const suffix = pick(["yssa", "thor", "alth", "umbra", "oraxis", "ystra", "akar"]);
   const name = (root + suffix).replace(/\s+/g, "");
 
   const titles: Record<string, string[]> = {
@@ -320,7 +322,8 @@ export async function generateLeviathan(options: {
         domain: `A wild domain of ${element}, sovereign to no Gate`,
         description: `An unbonded titan of Nero's Unformed, ${temperament}. Power that was never given a name to obey.`,
         material: `${name}'s ${element === "Water" ? "Pearl" : element === "Fire" ? "Cinder" : element === "Void" ? "Obsidian" : "Shard"}`,
-        weaknesses: temperament === "corrupted" ? ["Spirit", "the Tidesong"] : ["Fire", "Spirit"],
+        elementalWeaknesses: temperament === "corrupted" ? ["Spirit", "the Tidesong"] : ["Fire", "Spirit"],
+        note: options.named ? "named=true requested, but no canonical Leviathan exists for this element yet — returned a procedural Wild Godbeast." : undefined,
         canon: "STAGING — Wild Godbeast generator. Lock via /lock-decision before treating as canon.",
       }, null, 2),
     }],

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -283,6 +283,7 @@ export async function generateLeviathan(options: {
           tier: 3,
           class: "Leviathan / Wild Godbeast",
           bonded: false,
+          requestedElement: element,
           elements: n.elements,
           resonance: "Abyssal Hum",
           domain: n.domain,

--- a/packages/arcanea-mcp/src/tools/generators.ts
+++ b/packages/arcanea-mcp/src/tools/generators.ts
@@ -28,6 +28,20 @@ const godbeasts = [
   { name: "Kyuro", gate: 9, form: "Twin-Headed Unity Beast" },
 ];
 
+// Tier 3 Wild Godbeasts — unbonded titans outside the Ten Gates.
+// Canon: .arcanea/lore/leviathans/. Nethyssa is the named flagship.
+const leviathans = [
+  { name: "Nethyssa", title: "the Abyss That Dreams", elements: ["Water", "Void"], domain: "The Drowned Deep", material: "Nethyss Pearl", corruption: "The Drowned Shadow" },
+];
+
+const leviathanRoots: Record<string, string[]> = {
+  water: ["Neth", "Mar", "Thal", "Abyss", "Vor", "Drown"],
+  void: ["Nyx", "Umbra", "Vael", "Obsa", "Ten", "Mael"],
+  fire: ["Pyr", "Mag", "Cind", "Ash", "Ember"],
+  earth: ["Geo", "Tect", "Lith", "Mont", "Crag"],
+  wind: ["Aer", "Strat", "Gale", "Cael", "Cyclo"],
+};
+
 const nameRoots: Record<string, string[]> = {
   fire: ["Pyr", "Ign", "Flam", "Ard", "Cal"],
   water: ["Aqu", "Mar", "Und", "Flu", "Nix"],
@@ -241,6 +255,73 @@ export async function generateCreature(options: {
         description: `A ${size} ${element}-attuned creature.`,
         abilities: [`Control ${element.toLowerCase()} energy`, `Enhanced ${size === "massive" ? "devastating" : size === "large" ? "powerful" : "precise"} attacks`],
         habitat: `Found near ${element} sources`,
+      }, null, 2),
+    }],
+  };
+}
+
+export async function generateLeviathan(options: {
+  element?: string;
+  temperament?: "dreaming" | "stirring" | "waking" | "corrupted";
+  named?: boolean;
+}): Promise<ToolResult> {
+  // Tier 3 Wild Godbeast — unbonded titan outside the Ten Gates.
+  const element = options.element ?? pick(["Water", "Void", "Fire", "Earth", "Wind"]);
+  const temperament = options.temperament ?? pick(["dreaming", "stirring", "waking", "corrupted"] as const);
+
+  // Return the canonical flagship when asked for a named, Water/Void leviathan.
+  if (options.named && (element === "Water" || element === "Void")) {
+    const n = leviathans[0];
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          name: n.name,
+          title: n.title,
+          tier: 3,
+          class: "Leviathan / Wild Godbeast",
+          bonded: false,
+          elements: n.elements,
+          resonance: "Abyssal Hum",
+          domain: n.domain,
+          material: n.material,
+          corruption: n.corruption,
+          temperament,
+          canon: "STAGING — see .arcanea/lore/leviathans/nethyssa.md",
+        }, null, 2),
+      }],
+    };
+  }
+
+  const elementKey = element.toLowerCase();
+  const root = pick(leviathanRoots[elementKey] || leviathanRoots.void);
+  const suffix = pick(["yssa", " thor", "alth", "umbra", "oraxis", "ystra", "akar"]);
+  const name = (root + suffix).replace(/\s+/g, "");
+
+  const titles: Record<string, string[]> = {
+    dreaming: ["the Sleeping Tide", "the Dreaming Deep", "the Long Slumber"],
+    stirring: ["the Rising Dark", "the Stirring Below", "the Waking Want"],
+    waking: ["the Drowned Crown", "the Open Eye", "the World-Sinker"],
+    corrupted: ["the Unmade Tide", "the Shadow Below", "the Hungry Deep"],
+  };
+
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        name,
+        title: pick(titles[temperament]),
+        tier: 3,
+        class: "Leviathan / Wild Godbeast",
+        bonded: false,
+        elements: [element],
+        resonance: "Abyssal Hum",
+        temperament,
+        domain: `A wild domain of ${element}, sovereign to no Gate`,
+        description: `An unbonded titan of Nero's Unformed, ${temperament}. Power that was never given a name to obey.`,
+        material: `${name}'s ${element === "Water" ? "Pearl" : element === "Fire" ? "Cinder" : element === "Void" ? "Obsidian" : "Shard"}`,
+        weaknesses: temperament === "corrupted" ? ["Spirit", "the Tidesong"] : ["Fire", "Spirit"],
+        canon: "STAGING — Wild Godbeast generator. Lock via /lock-decision before treating as canon.",
       }, null, 2),
     }],
   };

--- a/packages/arcanea-mcp/tests/leviathan-generators.test.mjs
+++ b/packages/arcanea-mcp/tests/leviathan-generators.test.mjs
@@ -1,0 +1,460 @@
+/**
+ * leviathan-generators.test.mjs
+ *
+ * Unit tests for:
+ *   - generateLeviathan()  — imported from dist/tools/generators.js
+ *   - classifyCanonFit()   — from .arcanea/intake/canon-spectrum.ts (logic inlined;
+ *                            that directory is tool-agnostic, not part of tsconfig build)
+ *   - inferCaptureType()   — from .arcanea/intake/capture-types.ts (logic inlined)
+ *
+ * Run: node --test packages/arcanea-mcp/tests/leviathan-generators.test.mjs
+ */
+
+import { describe, it, before } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// ─── Helper ─────────────────────────────────────────────────────────────────
+
+function parseContent(result) {
+  assert.ok(result, 'result must be defined');
+  assert.ok(Array.isArray(result.content), 'result.content must be an array');
+  assert.ok(result.content.length >= 1, 'result.content must have at least one item');
+  assert.equal(result.content[0].type, 'text', 'content[0].type must be "text"');
+  return JSON.parse(result.content[0].text);
+}
+
+// ─── classifyCanonFit — inlined from .arcanea/intake/canon-spectrum.ts ──────
+// .arcanea/ is a tool-agnostic config dir, not part of the arcanea-mcp tsconfig.
+
+const SCALE_TO_TIER = {
+  mote: 'T0',
+  beast: 'T1',
+  shade: 'T2',
+  leviathan: 'T3',
+  godbeast: 'T4',
+};
+
+function classifyCanonFit(signals) {
+  const {
+    introducesNewEntity = false,
+    referencesLockedCanon = false,
+    creatureScale,
+    bonded = false,
+    techLeaning = false,
+  } = signals;
+
+  let spectrum;
+  if (techLeaning && !referencesLockedCanon && !introducesNewEntity) {
+    spectrum = 'tech';
+  } else if (referencesLockedCanon || introducesNewEntity) {
+    spectrum = techLeaning ? 'mixed' : 'canon';
+  } else {
+    spectrum = 'mixed';
+  }
+
+  let canonTier;
+  if (creatureScale) {
+    canonTier = SCALE_TO_TIER[creatureScale];
+  } else if (bonded) {
+    canonTier = 'T4';
+  } else if (introducesNewEntity) {
+    canonTier = 'T3'; // conservative: unbonded new entity forces the gate
+  } else {
+    canonTier = 'none';
+  }
+
+  const newEntityTier = canonTier === 'T3' || canonTier === 'T4';
+  const requiresCanonGate = newEntityTier || (introducesNewEntity && referencesLockedCanon);
+
+  return { spectrum, canonTier, requiresCanonGate };
+}
+
+// ─── inferCaptureType — inlined from .arcanea/intake/capture-types.ts ───────
+
+const CAPTURE_TYPE_LIST = [
+  {
+    id: 'lore-text',
+    label: 'Lore text',
+    mimeTypes: ['text/markdown', 'text/plain', 'application/pdf'],
+    extensions: ['.md', '.mdx', '.txt', '.pdf'],
+    defaultCanonTier: 'none',
+  },
+  {
+    id: 'monster-concept',
+    label: 'Monster concept',
+    mimeTypes: ['text/markdown', 'text/plain', 'image/png', 'image/jpeg', 'image/webp'],
+    extensions: ['.md', '.txt', '.png', '.jpg', '.jpeg', '.webp'],
+    defaultCanonTier: 'T3',
+  },
+  {
+    id: 'character-sketch',
+    label: 'Character sketch',
+    mimeTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'text/markdown', 'text/plain'],
+    extensions: ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.md', '.txt'],
+    defaultCanonTier: 'none',
+  },
+  {
+    id: 'concept-art',
+    label: 'Concept art',
+    mimeTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/svg+xml'],
+    extensions: ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.svg'],
+    defaultCanonTier: 'none',
+  },
+  {
+    id: 'guardian-wisdom',
+    label: 'Guardian wisdom',
+    mimeTypes: ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/x-m4a', 'audio/ogg', 'audio/webm'],
+    extensions: ['.m4a', '.mp3', '.wav', '.ogg', '.opus', '.webm'],
+    defaultCanonTier: 'none',
+  },
+  {
+    id: 'music-seed',
+    label: 'Music seed',
+    mimeTypes: ['audio/mpeg', 'audio/mp4', 'audio/wav'],
+    extensions: ['.m4a', '.mp3', '.wav'],
+    defaultCanonTier: 'none',
+  },
+  {
+    id: 'world-fragment',
+    label: 'World fragment',
+    mimeTypes: ['text/markdown', 'text/plain', 'application/json'],
+    extensions: ['.md', '.mdx', '.txt', '.json'],
+    defaultCanonTier: 'T1',
+  },
+];
+
+function inferCaptureType(mimeType, extension) {
+  const lowerExt = extension.toLowerCase();
+  const normalizedExt = lowerExt.startsWith('.') ? lowerExt : `.${lowerExt}`;
+  const byExt = CAPTURE_TYPE_LIST.find((c) => c.extensions.includes(normalizedExt));
+  if (byExt) return byExt;
+  return CAPTURE_TYPE_LIST.find((c) => c.mimeTypes.includes(mimeType));
+}
+
+// ─── generateLeviathan tests ─────────────────────────────────────────────────
+
+describe('generateLeviathan', () => {
+  let generateLeviathan;
+
+  before(async () => {
+    const mod = await import('../dist/tools/generators.js');
+    generateLeviathan = mod.generateLeviathan;
+  });
+
+  describe('named=true, element="Water" → canonical Nethyssa', () => {
+    it('returns the Nethyssa data block with correct name and title', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.equal(data.name, 'Nethyssa');
+      assert.equal(data.title, 'the Abyss That Dreams');
+    });
+
+    it('has tier=3, class=Leviathan/Wild Godbeast, bonded=false', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.equal(data.tier, 3);
+      assert.equal(data.class, 'Leviathan / Wild Godbeast');
+      assert.equal(data.bonded, false);
+    });
+
+    it('reflects the requested element back', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.equal(data.requestedElement, 'Water');
+    });
+
+    it('has the correct elements, resonance, domain, material, and corruption', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.deepEqual(data.elements, ['Water', 'Void']);
+      assert.equal(data.resonance, 'Abyssal Hum');
+      assert.equal(data.domain, 'The Drowned Deep');
+      assert.equal(data.material, 'Nethyss Pearl');
+      assert.equal(data.corruption, 'The Drowned Shadow');
+    });
+
+    it('marks canon as STAGING', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.ok(data.canon.includes('STAGING'), `expected "STAGING" in canon, got: ${data.canon}`);
+    });
+
+    it('does not carry a "note" field (canonical path, no fallback message)', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Water' });
+      const data = parseContent(result);
+      assert.equal(data.note, undefined);
+    });
+
+    it('also matches via lowercase input (element normalisation)', async () => {
+      const result = await generateLeviathan({ named: true, element: 'water' });
+      const data = parseContent(result);
+      assert.equal(data.name, 'Nethyssa');
+    });
+  });
+
+  describe('named=true, element="Fire" → procedural (no canonical Fire Leviathan yet)', () => {
+    it('returns a procedural Wild Godbeast with the named-fallback note', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Fire' });
+      const data = parseContent(result);
+      assert.ok(typeof data.note === 'string', 'note must be a string');
+      assert.ok(
+        data.note.includes('named=true requested'),
+        `note should describe the fallback, got: ${data.note}`,
+      );
+    });
+
+    it('has tier=3, class=Leviathan/Wild Godbeast, bonded=false', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Fire' });
+      const data = parseContent(result);
+      assert.equal(data.tier, 3);
+      assert.equal(data.class, 'Leviathan / Wild Godbeast');
+      assert.equal(data.bonded, false);
+    });
+
+    it('element array contains only Fire', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Fire' });
+      const data = parseContent(result);
+      assert.deepEqual(data.elements, ['Fire']);
+    });
+
+    it('is not Nethyssa', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Fire' });
+      const data = parseContent(result);
+      assert.notEqual(data.name, 'Nethyssa');
+    });
+
+    it('does not carry a corruption field (not a canonical Leviathan)', async () => {
+      const result = await generateLeviathan({ named: true, element: 'Fire' });
+      const data = parseContent(result);
+      assert.equal(data.corruption, undefined);
+    });
+  });
+
+  describe('named=false → always procedural, no note', () => {
+    it('returns tier=3, bonded=false', async () => {
+      const result = await generateLeviathan({ named: false });
+      const data = parseContent(result);
+      assert.equal(data.tier, 3);
+      assert.equal(data.bonded, false);
+    });
+
+    it('has class=Leviathan/Wild Godbeast', async () => {
+      const result = await generateLeviathan({ named: false });
+      const data = parseContent(result);
+      assert.equal(data.class, 'Leviathan / Wild Godbeast');
+    });
+
+    it('does not carry a "note" field', async () => {
+      const result = await generateLeviathan({ named: false });
+      const data = parseContent(result);
+      assert.equal(data.note, undefined);
+    });
+
+    it('has a name, title, resonance, domain, and material', async () => {
+      const result = await generateLeviathan({ named: false });
+      const data = parseContent(result);
+      assert.ok(typeof data.name === 'string' && data.name.length > 0, 'name must be a non-empty string');
+      assert.ok(typeof data.title === 'string' && data.title.length > 0, 'title must be a non-empty string');
+      assert.ok(typeof data.resonance === 'string', 'resonance must be a string');
+      assert.ok(typeof data.domain === 'string', 'domain must be a string');
+      assert.ok(typeof data.material === 'string', 'material must be a string');
+    });
+  });
+});
+
+// ─── classifyCanonFit tests ──────────────────────────────────────────────────
+
+describe('classifyCanonFit', () => {
+  it('empty signals → mixed spectrum, tier=none, no gate', () => {
+    const fit = classifyCanonFit({});
+    assert.equal(fit.spectrum, 'mixed');
+    assert.equal(fit.canonTier, 'none');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('techLeaning only → tech spectrum, tier=none, no gate', () => {
+    const fit = classifyCanonFit({ techLeaning: true });
+    assert.equal(fit.spectrum, 'tech');
+    assert.equal(fit.canonTier, 'none');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('referencesLockedCanon only → canon spectrum, tier=none, no gate', () => {
+    const fit = classifyCanonFit({ referencesLockedCanon: true });
+    assert.equal(fit.spectrum, 'canon');
+    assert.equal(fit.canonTier, 'none');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('techLeaning + referencesLockedCanon → mixed spectrum (blend), no gate', () => {
+    const fit = classifyCanonFit({ techLeaning: true, referencesLockedCanon: true });
+    assert.equal(fit.spectrum, 'mixed');
+    assert.equal(fit.canonTier, 'none');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('introducesNewEntity alone → canon spectrum, tier=T3 (conservative), gate required', () => {
+    const fit = classifyCanonFit({ introducesNewEntity: true });
+    assert.equal(fit.spectrum, 'canon');
+    assert.equal(fit.canonTier, 'T3');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('introducesNewEntity + referencesLockedCanon → gate required from both conditions', () => {
+    const fit = classifyCanonFit({ introducesNewEntity: true, referencesLockedCanon: true });
+    assert.equal(fit.spectrum, 'canon');
+    assert.equal(fit.canonTier, 'T3');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('creatureScale=mote → T0, no gate', () => {
+    const fit = classifyCanonFit({ creatureScale: 'mote' });
+    assert.equal(fit.canonTier, 'T0');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('creatureScale=beast → T1, no gate', () => {
+    const fit = classifyCanonFit({ creatureScale: 'beast' });
+    assert.equal(fit.canonTier, 'T1');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('creatureScale=shade → T2, no gate', () => {
+    const fit = classifyCanonFit({ creatureScale: 'shade' });
+    assert.equal(fit.canonTier, 'T2');
+    assert.equal(fit.requiresCanonGate, false);
+  });
+
+  it('creatureScale=leviathan → T3, gate required', () => {
+    const fit = classifyCanonFit({ creatureScale: 'leviathan', introducesNewEntity: true });
+    assert.equal(fit.canonTier, 'T3');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('creatureScale=godbeast → T4, gate required', () => {
+    const fit = classifyCanonFit({ creatureScale: 'godbeast', introducesNewEntity: true });
+    assert.equal(fit.canonTier, 'T4');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('bonded=true, no scale → T4 (only the Ten are bonded), gate required', () => {
+    const fit = classifyCanonFit({ bonded: true });
+    assert.equal(fit.canonTier, 'T4');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('creatureScale wins over bonded when both are set', () => {
+    const fit = classifyCanonFit({ creatureScale: 'leviathan', bonded: true });
+    assert.equal(fit.canonTier, 'T3'); // scale wins
+    assert.equal(fit.requiresCanonGate, true);
+  });
+
+  it('Nethyssa capture profile → canon spectrum, T3, gate required', () => {
+    // Represents a new Leviathan creature concept capture
+    const fit = classifyCanonFit({
+      introducesNewEntity: true,
+      referencesLockedCanon: false,
+      creatureScale: 'leviathan',
+    });
+    assert.equal(fit.spectrum, 'canon');
+    assert.equal(fit.canonTier, 'T3');
+    assert.equal(fit.requiresCanonGate, true);
+  });
+});
+
+// ─── inferCaptureType tests ──────────────────────────────────────────────────
+
+describe('inferCaptureType', () => {
+  describe('extension-first routing', () => {
+    it('.json → world-fragment (defaultCanonTier=T1)', () => {
+      const result = inferCaptureType('application/json', '.json');
+      assert.equal(result.id, 'world-fragment');
+      assert.equal(result.defaultCanonTier, 'T1');
+    });
+
+    it('json (no leading dot) → world-fragment (normalisation)', () => {
+      const result = inferCaptureType('application/json', 'json');
+      assert.equal(result.id, 'world-fragment');
+    });
+
+    it('.svg → concept-art', () => {
+      const result = inferCaptureType('image/svg+xml', '.svg');
+      assert.equal(result.id, 'concept-art');
+    });
+
+    it('.opus → guardian-wisdom (only type with .opus)', () => {
+      const result = inferCaptureType('audio/ogg', '.opus');
+      assert.equal(result.id, 'guardian-wisdom');
+    });
+
+    it('.pdf → lore-text', () => {
+      const result = inferCaptureType('application/pdf', '.pdf');
+      assert.equal(result.id, 'lore-text');
+    });
+
+    it('.webm → guardian-wisdom', () => {
+      const result = inferCaptureType('audio/webm', '.webm');
+      assert.equal(result.id, 'guardian-wisdom');
+    });
+
+    it('.png → monster-concept (first .png match, defaultCanonTier=T3)', () => {
+      // .png appears in: monster-concept(1), character-sketch(2), concept-art(3).
+      // Extension find() returns the first match in CAPTURE_TYPE_LIST order.
+      const result = inferCaptureType('image/png', '.png');
+      assert.equal(result.id, 'monster-concept');
+      assert.equal(result.defaultCanonTier, 'T3');
+    });
+
+    it('unknown extension → undefined', () => {
+      const result = inferCaptureType('application/octet-stream', '.xyz_arcanea_unknown');
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('mime fallback (when extension is unknown)', () => {
+    it('audio/ogg + unknown extension → guardian-wisdom via mime', () => {
+      const result = inferCaptureType('audio/ogg', '.unk');
+      assert.equal(result.id, 'guardian-wisdom');
+    });
+
+    it('audio/x-m4a + unknown extension → guardian-wisdom via mime', () => {
+      const result = inferCaptureType('audio/x-m4a', '.unk');
+      assert.equal(result.id, 'guardian-wisdom');
+    });
+
+    it('image/svg+xml + unknown extension → concept-art via mime', () => {
+      const result = inferCaptureType('image/svg+xml', '.unk');
+      assert.equal(result.id, 'concept-art');
+    });
+
+    it('unknown mime + unknown extension → undefined', () => {
+      const result = inferCaptureType('model/gltf-binary', '.glb');
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('canon tier priors by capture type', () => {
+    it('monster-concept carries defaultCanonTier=T3', () => {
+      // .webp is unique first-match for monster-concept
+      const result = inferCaptureType('image/webp', '.webp');
+      // .webp appears in monster-concept(1), character-sketch(2), concept-art(3)
+      assert.equal(result.id, 'monster-concept');
+      assert.equal(result.defaultCanonTier, 'T3');
+    });
+
+    it('world-fragment carries defaultCanonTier=T1', () => {
+      const result = inferCaptureType('application/json', '.json');
+      assert.equal(result.defaultCanonTier, 'T1');
+    });
+
+    it('lore-text carries defaultCanonTier=none', () => {
+      const result = inferCaptureType('application/pdf', '.pdf');
+      assert.equal(result.defaultCanonTier, 'none');
+    });
+
+    it('guardian-wisdom carries defaultCanonTier=none', () => {
+      const result = inferCaptureType('audio/ogg', '.opus');
+      assert.equal(result.defaultCanonTier, 'none');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,34 +353,6 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.17)
 
-  packages/ai-agents:
-    dependencies:
-      '@elizaos/core':
-        specifier: ^1.0.0
-        version: 1.7.2
-      '@elizaos/plugin-bootstrap':
-        specifier: ^1.0.0
-        version: 1.7.2(whatwg-url@7.1.0)
-      '@elizaos/plugin-evm':
-        specifier: ^1.0.0
-        version: 1.0.13(@solana/wallet-adapter-base@0.9.27)(@solana/web3.js@1.98.4)(postcss@8.5.6)(react@19.0.0)(tsx@4.21.0)(typescript@5.9.3)(viem@2.46.3)(whatwg-url@7.1.0)
-      '@elizaos/plugin-sql':
-        specifier: ^1.0.0
-        version: 1.7.2
-      ethers:
-        specifier: ^6.11.0
-        version: 6.16.0
-      viem:
-        specifier: ^2.13.0
-        version: 2.46.3(typescript@5.9.3)
-    devDependencies:
-      '@types/node':
-        specifier: ^20.11.0
-        version: 20.19.17
-      typescript:
-        specifier: ^5.3.3
-        version: 5.9.3
-
   packages/ai-core:
     dependencies:
       '@google/generative-ai':
@@ -567,36 +539,6 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
-      typescript:
-        specifier: ^5.3.3
-        version: 5.9.3
-
-  packages/contracts:
-    devDependencies:
-      '@chainlink/contracts':
-        specifier: ^1.1.0
-        version: 1.5.0(@types/node@20.19.17)(ethers@6.16.0)
-      '@nomicfoundation/hardhat-ignition':
-        specifier: ^0.15.0
-        version: 0.15.16(@nomicfoundation/hardhat-verify@2.1.3)(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-toolbox':
-        specifier: ^5.0.0
-        version: 5.0.0(@nomicfoundation/hardhat-chai-matchers@2.1.2)(@nomicfoundation/hardhat-ethers@3.1.3)(@nomicfoundation/hardhat-ignition-ethers@0.15.17)(@nomicfoundation/hardhat-network-helpers@1.1.2)(@nomicfoundation/hardhat-verify@2.1.3)(@typechain/ethers-v6@0.5.1)(@typechain/hardhat@9.1.0)(@types/chai@4.3.20)(@types/mocha@10.0.10)(@types/node@20.19.17)(chai@4.5.0)(ethers@6.16.0)(hardhat-gas-reporter@2.3.0)(hardhat@2.28.6)(solidity-coverage@0.8.17)(ts-node@10.9.2)(typechain@8.3.2)(typescript@5.9.3)
-      '@openzeppelin/contracts':
-        specifier: ^5.0.0
-        version: 5.6.1
-      hardhat:
-        specifier: ^2.22.0
-        version: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      hardhat-gas-reporter:
-        specifier: ^2.2.0
-        version: 2.3.0(hardhat@2.28.6)(typescript@5.9.3)
-      solidity-coverage:
-        specifier: ^0.8.10
-        version: 0.8.17(hardhat@2.28.6)
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.17)(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1058,34 +1000,6 @@ importers:
 
 packages:
 
-  /@0no-co/graphql.web@1.2.0(graphql@16.13.0):
-    resolution: {integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    peerDependenciesMeta:
-      graphql:
-        optional: true
-    dependencies:
-      graphql: 16.13.0
-    dev: false
-
-  /@0no-co/graphqlsp@1.15.2(graphql@16.13.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-Ys031WnS3sTQQBtRTkQsYnw372OlW72ais4sp0oh2UMPRNyxxnq85zRfU4PIdoy9kWriysPT5BYAkgIxhbonFA==}
-    peerDependencies:
-      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
-    dependencies:
-      '@gql.tada/internal': 1.0.8(graphql@16.13.0)(typescript@5.9.3)
-      graphql: 16.13.0
-      typescript: 5.9.3
-    dev: false
-
-  /@adraffy/ens-normalize@1.10.1:
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
-
-  /@adraffy/ens-normalize@1.11.1:
-    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
-
   /@ai-sdk/anthropic@0.0.9(zod@3.25.76):
     resolution: {integrity: sha512-pRudgyxsxLTnQEDnvYzh/lTSSijxa2eifAjbJO/lNp9jkFGl85Sa2pNhNVWKT9I/E6B/Zv4LyyIH5WDEJkwRPA==}
     engines: {node: '>=18'}
@@ -1329,17 +1243,6 @@ packages:
       - encoding
     dev: false
 
-  /@arbitrum/nitro-contracts@3.0.0:
-    resolution: {integrity: sha512-7VzNW9TxvrX9iONDDsi7AZlEUPa6z+cjBkB4Mxlnog9VQZAapRC3CdRXyUzHnBYmUhRzyNJdyxkWPw59QGcLmA==}
-    requiresBuild: true
-    dependencies:
-      '@offchainlabs/upgrade-executor': 1.1.0-beta.0
-      '@openzeppelin/contracts': 4.7.3
-      '@openzeppelin/contracts-upgradeable': 4.7.3
-      patch-package: 6.5.1
-      solady: 0.0.182
-    dev: true
-
   /@azu/format-text@1.0.2:
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
     dev: true
@@ -1493,7 +1396,7 @@ packages:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1609,7 +1512,7 @@ packages:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1627,62 +1530,6 @@ packages:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
     dev: false
-
-  /@bigmi/core@0.7.0(bs58@6.0.0)(react@19.0.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-77br/G4rr4LFgLwYPQs/TZUlB/XVljgSrsseb0J6xCSs3DxomfnKQuKqTksN7IcwuDDEL22xBpyt9JZpoO+lQg==}
-    peerDependencies:
-      bs58: ^6.0.0
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bech32: 2.0.0
-      bitcoinjs-lib: 7.0.1(typescript@5.9.3)
-      bs58: 6.0.0
-      eventemitter3: 5.0.4
-      zustand: 5.0.11(react@19.0.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-    dev: false
-
-  /@bitcoinerlab/secp256k1@1.2.0:
-    resolution: {integrity: sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==}
-    dependencies:
-      '@noble/curves': 1.9.7
-    dev: false
-
-  /@cfworker/json-schema@4.1.1:
-    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
-    dev: false
-
-  /@chainlink/contracts@1.5.0(@types/node@20.19.17)(ethers@6.16.0):
-    resolution: {integrity: sha512-1fGJwjvivqAxvVOTqZUEXGR54CATtg0vjcXgSIk4Cfoad2nUhSG/qaWHXjLg1CkNTeOoteoxGQcpP/HiA5HsUA==}
-    engines: {node: '>=22', pnpm: '>=10'}
-    dependencies:
-      '@arbitrum/nitro-contracts': 3.0.0
-      '@changesets/cli': 2.29.7(@types/node@20.19.17)
-      '@changesets/get-github-info': 0.6.0
-      '@eslint/eslintrc': 3.3.3
-      '@eth-optimism/contracts': 0.6.0(ethers@6.16.0)
-      '@openzeppelin/contracts-4.7.3': /@openzeppelin/contracts@4.7.3
-      '@openzeppelin/contracts-4.8.3': /@openzeppelin/contracts@4.8.3
-      '@openzeppelin/contracts-4.9.6': /@openzeppelin/contracts@4.9.6
-      '@openzeppelin/contracts-5.0.2': /@openzeppelin/contracts@5.0.2
-      '@openzeppelin/contracts-5.1.0': /@openzeppelin/contracts@5.1.0
-      '@openzeppelin/contracts-upgradeable': 4.9.6
-      '@scroll-tech/contracts': 2.0.0
-      '@zksync/contracts': github.com/matter-labs/era-contracts/446d391d34bdb48255d5f8fef8a8248925fc98b9
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - ethers
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /@changesets/apply-release-plan@7.0.13:
     resolution: {integrity: sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==}
@@ -1782,15 +1629,6 @@ packages:
       semver: 7.7.2
     dev: true
 
-  /@changesets/get-github-info@0.6.0:
-    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
-    dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /@changesets/get-release-plan@4.0.13:
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
     dependencies:
@@ -1874,13 +1712,6 @@ packages:
       prettier: 2.8.8
     dev: true
 
-  /@colors/colors@1.5.0:
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -1890,163 +1721,7 @@ packages:
 
   /@drizzle-team/brocli@0.10.2:
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
-
-  /@electric-sql/pglite@0.3.15:
-    resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
-    dev: false
-
-  /@elizaos/core@1.7.2:
-    resolution: {integrity: sha512-NUw+YIXTejCCB07jevJ6cTbd/FKTqVoPwDrMMuBcjHeM+9UlQKFadDJooWEUREf37WS4KBegwLUOnr9H9CXpcw==}
-    dependencies:
-      '@langchain/core': 1.1.29
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.29)
-      adze: 2.3.0
-      crypto-browserify: 3.12.1
-      dotenv: 17.3.1
-      fast-redact: 3.5.0
-      glob: 13.0.6
-      handlebars: 4.7.8
-      pdfjs-dist: 5.4.624
-      unique-names-generator: 4.7.1
-      uuid: 13.0.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-    dev: false
-
-  /@elizaos/plugin-bootstrap@1.7.2(whatwg-url@7.1.0):
-    resolution: {integrity: sha512-1NDnGmTXsCaGknyT+sYagEPyHPug4HIJl0XKmoh446mk5EKL9VFHAi4tnBkIVSoLWYKuXdAew/p8jwRTPlPeXw==}
-    peerDependencies:
-      whatwg-url: 7.1.0
-    dependencies:
-      '@elizaos/core': 1.7.2
-      '@elizaos/plugin-sql': 1.7.2
-      bun: 1.3.10
-      whatwg-url: 7.1.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - openai
-      - pg-native
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@elizaos/plugin-evm@1.0.13(@solana/wallet-adapter-base@0.9.27)(@solana/web3.js@1.98.4)(postcss@8.5.6)(react@19.0.0)(tsx@4.21.0)(typescript@5.9.3)(viem@2.46.3)(whatwg-url@7.1.0):
-    resolution: {integrity: sha512-AZkp9j9I47KeREXsrWCcZNWkqu8WWN1f2hIePWwHGcSV+M9tcek91vZOOVCsQNMPqBgqf4nm/1P4WpsdNfURMg==}
-    peerDependencies:
-      whatwg-url: 7.1.0
-    dependencies:
-      '@elizaos/core': 1.7.2
-      '@lifi/data-types': 5.15.5
-      '@lifi/sdk': 3.15.7(@solana/wallet-adapter-base@0.9.27)(@solana/web3.js@1.98.4)(react@19.0.0)(typescript@5.9.3)(viem@2.46.3)
-      '@lifi/types': 17.65.0(typescript@5.9.3)
-      tsup: 8.5.0(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
-      whatwg-url: 7.1.0
-    transitivePeerDependencies:
-      - '@gql.tada/svelte-support'
-      - '@gql.tada/vue-support'
-      - '@microsoft/api-extractor'
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - '@solana/wallet-adapter-base'
-      - '@solana/web3.js'
-      - '@swc/core'
-      - '@types/react'
-      - bufferutil
-      - immer
-      - jiti
-      - openai
-      - postcss
-      - react
-      - supports-color
-      - tsx
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - viem
-      - yaml
-      - zod
-    dev: false
-
-  /@elizaos/plugin-sql@1.7.2:
-    resolution: {integrity: sha512-LYDcSm9nzdx8wpdcsI/74Yn5ZSeV0vneT151pyMHHDNF1erhslnj/ZLPqBmKPpSk24dHXitZsPI1Jp/5OJcKCw==}
-    dependencies:
-      '@electric-sql/pglite': 0.3.15
-      '@elizaos/core': 1.7.2
-      '@neondatabase/serverless': 1.0.2
-      dotenv: 17.3.1
-      drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@neondatabase/serverless@1.0.2)(pg@8.19.0)
-      pg: 8.19.0
-      uuid: 13.0.0
-      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - openai
-      - pg-native
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-      - supports-color
-      - utf-8-validate
-    dev: false
+    dev: true
 
   /@emnapi/core@1.8.1:
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -2078,6 +1753,7 @@ packages:
     dependencies:
       esbuild: 0.18.20
       source-map-support: 0.5.21
+    dev: true
 
   /@esbuild-kit/esm-loader@2.6.5:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
@@ -2085,6 +1761,7 @@ packages:
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.0
+    dev: true
 
   /@esbuild/aix-ppc64@0.19.12:
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -2122,21 +1799,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/aix-ppc64@0.25.12:
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/aix-ppc64@0.27.3:
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.18.20:
@@ -2145,6 +1814,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.19.12:
@@ -2183,21 +1853,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.25.12:
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/android-arm64@0.27.3:
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -2206,6 +1868,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.19.12:
@@ -2244,21 +1907,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.25.12:
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/android-arm@0.27.3:
     resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.18.20:
@@ -2267,6 +1922,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.19.12:
@@ -2305,21 +1961,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.25.12:
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/android-x64@0.27.3:
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -2328,6 +1976,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.19.12:
@@ -2366,21 +2015,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.25.12:
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/darwin-arm64@0.27.3:
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.18.20:
@@ -2389,6 +2030,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.12:
@@ -2427,21 +2069,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.25.12:
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/darwin-x64@0.27.3:
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -2450,6 +2084,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.12:
@@ -2488,21 +2123,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.25.12:
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/freebsd-arm64@0.27.3:
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.18.20:
@@ -2511,6 +2138,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.12:
@@ -2549,21 +2177,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.25.12:
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/freebsd-x64@0.27.3:
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -2572,6 +2192,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.19.12:
@@ -2610,21 +2231,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.25.12:
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-arm64@0.27.3:
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.18.20:
@@ -2633,6 +2246,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.19.12:
@@ -2671,21 +2285,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.25.12:
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-arm@0.27.3:
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -2694,6 +2300,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.19.12:
@@ -2732,21 +2339,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.25.12:
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-ia32@0.27.3:
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -2755,6 +2354,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.12:
@@ -2793,21 +2393,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.25.12:
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-loong64@0.27.3:
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -2816,6 +2408,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.19.12:
@@ -2854,21 +2447,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.25.12:
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-mips64el@0.27.3:
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.18.20:
@@ -2877,6 +2462,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.12:
@@ -2915,21 +2501,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.25.12:
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-ppc64@0.27.3:
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -2938,6 +2516,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.19.12:
@@ -2976,21 +2555,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.25.12:
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-riscv64@0.27.3:
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.18.20:
@@ -2999,6 +2570,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.12:
@@ -3037,21 +2609,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.25.12:
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-s390x@0.27.3:
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -3060,6 +2624,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.19.12:
@@ -3098,21 +2663,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.25.12:
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/linux-x64@0.27.3:
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-arm64@0.24.2:
@@ -3124,21 +2681,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-arm64@0.25.12:
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/netbsd-arm64@0.27.3:
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.18.20:
@@ -3147,6 +2696,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.12:
@@ -3185,21 +2735,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.25.12:
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/netbsd-x64@0.27.3:
     resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-arm64@0.24.2:
@@ -3211,21 +2753,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-arm64@0.25.12:
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/openbsd-arm64@0.27.3:
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -3234,6 +2768,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.19.12:
@@ -3272,30 +2807,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.25.12:
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/openbsd-x64@0.27.3:
     resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/openharmony-arm64@0.25.12:
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-    requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /@esbuild/openharmony-arm64@0.27.3:
@@ -3304,6 +2822,7 @@ packages:
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.18.20:
@@ -3312,6 +2831,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.12:
@@ -3350,21 +2870,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.25.12:
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/sunos-x64@0.27.3:
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.18.20:
@@ -3373,6 +2885,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.19.12:
@@ -3411,21 +2924,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.25.12:
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/win32-arm64@0.27.3:
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.18.20:
@@ -3434,6 +2939,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.19.12:
@@ -3472,21 +2978,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.25.12:
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/win32-ia32@0.27.3:
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.18.20:
@@ -3495,6 +2993,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.19.12:
@@ -3533,21 +3032,13 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.25.12:
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@esbuild/win32-x64@0.27.3:
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.9.1(eslint@8.57.1):
@@ -3580,7 +3071,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3605,7 +3096,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -3622,7 +3113,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3657,315 +3148,6 @@ packages:
       levn: 0.4.1
     dev: true
 
-  /@eth-optimism/contracts@0.6.0(ethers@6.16.0):
-    resolution: {integrity: sha512-vQ04wfG9kMf1Fwy3FEMqH2QZbgS0gldKhcBeBUPfO8zu68L61VI97UDXmsMQXzTsEAxK8HnokW3/gosl4/NW3w==}
-    peerDependencies:
-      ethers: ^5
-    dependencies:
-      '@eth-optimism/core-utils': 0.12.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      ethers: 6.16.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
-  /@eth-optimism/core-utils@0.12.0:
-    resolution: {integrity: sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==}
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/contracts': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/providers': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-      bufio: 1.2.3
-      chai: 4.5.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
-  /@ethereumjs/rlp@4.0.1:
-    resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
-  /@ethereumjs/rlp@5.0.2:
-    resolution: {integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: true
-
-  /@ethereumjs/util@8.1.0:
-    resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@ethereumjs/rlp': 4.0.1
-      ethereum-cryptography: 2.2.1
-      micro-ftch: 0.3.1
-    dev: true
-
-  /@ethereumjs/util@9.1.0:
-    resolution: {integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@ethereumjs/rlp': 5.0.2
-      ethereum-cryptography: 2.2.1
-    dev: true
-
-  /@ethersproject/abi@5.8.0:
-    resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-    dev: true
-
-  /@ethersproject/abstract-provider@5.8.0:
-    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-    dev: true
-
-  /@ethersproject/abstract-signer@5.8.0:
-    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-    dev: true
-
-  /@ethersproject/address@5.6.1:
-    resolution: {integrity: sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==}
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-    dev: true
-
-  /@ethersproject/address@5.8.0:
-    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-    dev: true
-
-  /@ethersproject/base64@5.8.0:
-    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-    dev: true
-
-  /@ethersproject/basex@5.8.0:
-    resolution: {integrity: sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/properties': 5.8.0
-    dev: true
-
-  /@ethersproject/bignumber@5.8.0:
-    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.3
-    dev: true
-
-  /@ethersproject/bytes@5.8.0:
-    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/constants@5.8.0:
-    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-    dev: true
-
-  /@ethersproject/contracts@5.8.0:
-    resolution: {integrity: sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==}
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-    dev: true
-
-  /@ethersproject/hash@5.8.0:
-    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-    dev: true
-
-  /@ethersproject/keccak256@5.8.0:
-    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      js-sha3: 0.8.0
-    dev: true
-
-  /@ethersproject/logger@5.8.0:
-    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
-    dev: true
-
-  /@ethersproject/networks@5.8.0:
-    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/properties@5.8.0:
-    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/providers@5.8.0:
-    resolution: {integrity: sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==}
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/basex': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/random': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/sha2': 5.8.0
-      '@ethersproject/strings': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-      bech32: 1.1.4
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
-  /@ethersproject/random@5.8.0:
-    resolution: {integrity: sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/rlp@5.8.0:
-    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/sha2@5.8.0:
-    resolution: {integrity: sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      hash.js: 1.1.7
-    dev: true
-
-  /@ethersproject/signing-key@5.8.0:
-    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.3
-      elliptic: 6.6.1
-      hash.js: 1.1.7
-    dev: true
-
-  /@ethersproject/strings@5.8.0:
-    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/transactions@5.8.0:
-    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-    dev: true
-
-  /@ethersproject/units@5.8.0:
-    resolution: {integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==}
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-    dev: true
-
-  /@ethersproject/web@5.8.0:
-    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-    dependencies:
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-    dev: true
-
   /@fal-ai/client@1.9.4:
     resolution: {integrity: sha512-mDjF2QDq+oficSSxzmErNkseQeRXnvUBEhJy39n4PPe7jRPZeSqM2SNb27SW50rDtCtay+stwFU8zRZehlt1Qg==}
     engines: {node: '>=18.0.0'}
@@ -3974,11 +3156,6 @@ packages:
       eventsource-parser: 1.1.2
       robot3: 0.4.1
     dev: false
-
-  /@fastify/busboy@2.1.1:
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-    dev: true
 
   /@floating-ui/core@1.7.3:
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -4029,45 +3206,6 @@ packages:
   /@google/generative-ai@0.21.0:
     resolution: {integrity: sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==}
     engines: {node: '>=18.0.0'}
-    dev: false
-
-  /@gql.tada/cli-utils@1.7.2(@0no-co/graphqlsp@1.15.2)(graphql@16.13.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-Qbc7hbLvCz6IliIJpJuKJa9p05b2Jona7ov7+qofCsMRxHRZE1kpAmZMvL8JCI4c0IagpIlWNaMizXEQUe8XjQ==}
-    peerDependencies:
-      '@0no-co/graphqlsp': ^1.12.13
-      '@gql.tada/svelte-support': 1.0.1
-      '@gql.tada/vue-support': 1.0.1
-      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      '@gql.tada/svelte-support':
-        optional: true
-      '@gql.tada/vue-support':
-        optional: true
-    dependencies:
-      '@0no-co/graphqlsp': 1.15.2(graphql@16.13.0)(typescript@5.9.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.13.0)(typescript@5.9.3)
-      graphql: 16.13.0
-      typescript: 5.9.3
-    dev: false
-
-  /@gql.tada/internal@1.0.8(graphql@16.13.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==}
-    peerDependencies:
-      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-      typescript: ^5.0.0
-    dependencies:
-      '@0no-co/graphql.web': 1.2.0(graphql@16.13.0)
-      graphql: 16.13.0
-      typescript: 5.9.3
-    dev: false
-
-  /@graphql-typed-document-node/core@3.2.0(graphql@16.13.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 16.13.0
     dev: false
 
   /@gsap/react@2.1.2(gsap@3.14.2)(react@19.0.0):
@@ -4124,7 +3262,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4440,90 +3578,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
-  /@langchain/core@1.1.29:
-    resolution: {integrity: sha512-BPoegTtIdZX4gl2kxcSXAlLrrJFl1cxeRsk9DM/wlIuvyPrFwjWqrEK5NwF5diDt5XSArhQxIFaifGAl4F7fgw==}
-    engines: {node: '>=20'}
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.21
-      langsmith: 0.5.7
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      uuid: 11.1.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-    dev: false
-
-  /@langchain/textsplitters@1.0.1(@langchain/core@1.1.29):
-    resolution: {integrity: sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@langchain/core': ^1.0.0
-    dependencies:
-      '@langchain/core': 1.1.29
-      js-tiktoken: 1.0.21
-    dev: false
-
-  /@lifi/data-types@5.15.5:
-    resolution: {integrity: sha512-nMlXxVZTClaMNS1fty6BV7E+gyKFnOgYAIMQ1kAJLv97TdLWBwQxUVDWPI5zJKKIT/Y14PJ7H6ONx+5Gq0kRGw==}
-    dependencies:
-      '@lifi/types': 16.10.0
-    dev: false
-
-  /@lifi/sdk@3.15.7(@solana/wallet-adapter-base@0.9.27)(@solana/web3.js@1.98.4)(react@19.0.0)(typescript@5.9.3)(viem@2.46.3):
-    resolution: {integrity: sha512-Rhptfhv10TnsluFgmE7XCsZ7uM2A9mwvq5iCNkwhQmBLAksiehbr8jz0CEyArKxijXQrdvCTGLxNrGIUMfvMjw==}
-    peerDependencies:
-      '@solana/wallet-adapter-base': ^0.9.0
-      '@solana/web3.js': ^1.98.0
-      viem: ^2.21.0
-    dependencies:
-      '@bigmi/core': 0.7.0(bs58@6.0.0)(react@19.0.0)(typescript@5.9.3)
-      '@bitcoinerlab/secp256k1': 1.2.0
-      '@lifi/types': 17.65.0(typescript@5.9.3)
-      '@mysten/sui': 1.45.2(typescript@5.9.3)
-      '@mysten/wallet-standard': 0.19.9(typescript@5.9.3)
-      '@noble/curves': 1.9.7
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4)
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
-      bech32: 2.0.0
-      bitcoinjs-lib: 7.0.1(typescript@5.9.3)
-      bs58: 6.0.0
-      viem: 2.46.3(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@gql.tada/svelte-support'
-      - '@gql.tada/vue-support'
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /@lifi/types@16.10.0:
-    resolution: {integrity: sha512-bwlhO7rwb2vXCnHkbjLQSUQciAG6pF0a4I7eQ1Gnfuedm4vHTjmWoBRwAK5GjgwL9k4Qokppt1OYxeCNXHsxcg==}
-    dev: false
-
-  /@lifi/types@17.65.0(typescript@5.9.3):
-    resolution: {integrity: sha512-2COF1WimbFiPv51x4T1lvXSs8sRB6CP0SzOTCt7xCwaaeMBLczuuJmF0r10pY9JPxdzbJtVMM83Za3uCslqlWA==}
-    dependencies:
-      viem: 2.46.3(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
@@ -4588,173 +3642,6 @@ packages:
     engines: {node: '>= 18'}
     dev: false
 
-  /@mysten/bcs@1.9.2:
-    resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
-    dependencies:
-      '@mysten/utils': 0.2.0
-      '@scure/base': 1.2.6
-    dev: false
-
-  /@mysten/sui@1.45.2(typescript@5.9.3):
-    resolution: {integrity: sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.0)
-      '@mysten/bcs': 1.9.2
-      '@mysten/utils': 0.2.0
-      '@noble/curves': 1.9.4
-      '@noble/hashes': 1.8.0
-      '@protobuf-ts/grpcweb-transport': 2.11.1
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-      '@scure/base': 1.2.6
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      gql.tada: 1.9.0(graphql@16.13.0)(typescript@5.9.3)
-      graphql: 16.13.0
-      poseidon-lite: 0.2.1
-      valibot: 1.2.0(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@gql.tada/svelte-support'
-      - '@gql.tada/vue-support'
-      - typescript
-    dev: false
-
-  /@mysten/utils@0.2.0:
-    resolution: {integrity: sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==}
-    dependencies:
-      '@scure/base': 1.2.6
-    dev: false
-
-  /@mysten/wallet-standard@0.19.9(typescript@5.9.3):
-    resolution: {integrity: sha512-jHFt+62os7x7y+4ZVMLck8WSanEO9b8deCD+VApUQkdAHA99TuxbREaujQTjnGQN5DaGEz8wQgeBPqxRY/vKQA==}
-    dependencies:
-      '@mysten/sui': 1.45.2(typescript@5.9.3)
-      '@wallet-standard/core': 1.1.1
-    transitivePeerDependencies:
-      - '@gql.tada/svelte-support'
-      - '@gql.tada/vue-support'
-      - typescript
-    dev: false
-
-  /@napi-rs/canvas-android-arm64@0.1.95:
-    resolution: {integrity: sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-darwin-arm64@0.1.95:
-    resolution: {integrity: sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-darwin-x64@0.1.95:
-    resolution: {integrity: sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-arm-gnueabihf@0.1.95:
-    resolution: {integrity: sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-arm64-gnu@0.1.95:
-    resolution: {integrity: sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-arm64-musl@0.1.95:
-    resolution: {integrity: sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-riscv64-gnu@0.1.95:
-    resolution: {integrity: sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-x64-gnu@0.1.95:
-    resolution: {integrity: sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-linux-x64-musl@0.1.95:
-    resolution: {integrity: sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-win32-arm64-msvc@0.1.95:
-    resolution: {integrity: sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas-win32-x64-msvc@0.1.95:
-    resolution: {integrity: sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@napi-rs/canvas@0.1.95:
-    resolution: {integrity: sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w==}
-    engines: {node: '>= 10'}
-    requiresBuild: true
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.95
-      '@napi-rs/canvas-darwin-arm64': 0.1.95
-      '@napi-rs/canvas-darwin-x64': 0.1.95
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.95
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.95
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-x64-musl': 0.1.95
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.95
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.95
-    dev: false
-    optional: true
-
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
@@ -4768,14 +3655,6 @@ packages:
   /@neondatabase/serverless@0.9.5:
     resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
     dependencies:
-      '@types/pg': 8.11.6
-    dev: false
-
-  /@neondatabase/serverless@1.0.2:
-    resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
-    engines: {node: '>=19.0.0'}
-    dependencies:
-      '@types/node': 22.19.11
       '@types/pg': 8.11.6
     dev: false
 
@@ -4861,74 +3740,6 @@ packages:
     dev: false
     optional: true
 
-  /@noble/ciphers@1.3.0:
-    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
-    engines: {node: ^14.21.3 || >=16}
-
-  /@noble/curves@1.2.0:
-    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
-    dependencies:
-      '@noble/hashes': 1.3.2
-
-  /@noble/curves@1.4.2:
-    resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
-    dependencies:
-      '@noble/hashes': 1.4.0
-    dev: true
-
-  /@noble/curves@1.8.2:
-    resolution: {integrity: sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==}
-    engines: {node: ^14.21.3 || >=16}
-    dependencies:
-      '@noble/hashes': 1.7.2
-    dev: true
-
-  /@noble/curves@1.9.1:
-    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
-    engines: {node: ^14.21.3 || >=16}
-    dependencies:
-      '@noble/hashes': 1.8.0
-
-  /@noble/curves@1.9.4:
-    resolution: {integrity: sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==}
-    engines: {node: ^14.21.3 || >=16}
-    dependencies:
-      '@noble/hashes': 1.8.0
-    dev: false
-
-  /@noble/curves@1.9.7:
-    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
-    engines: {node: ^14.21.3 || >=16}
-    dependencies:
-      '@noble/hashes': 1.8.0
-    dev: false
-
-  /@noble/hashes@1.2.0:
-    resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
-    dev: true
-
-  /@noble/hashes@1.3.2:
-    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
-    engines: {node: '>= 16'}
-
-  /@noble/hashes@1.4.0:
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
-    engines: {node: '>= 16'}
-    dev: true
-
-  /@noble/hashes@1.7.2:
-    resolution: {integrity: sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==}
-    engines: {node: ^14.21.3 || >=16}
-    dev: true
-
-  /@noble/hashes@1.8.0:
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
-
-  /@noble/secp256k1@1.7.1:
-    resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
-    dev: true
-
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -4952,439 +3763,16 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
-  /@nomicfoundation/edr-darwin-arm64@0.12.0-next.23:
-    resolution: {integrity: sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-darwin-x64@0.12.0-next.23:
-    resolution: {integrity: sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23:
-    resolution: {integrity: sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23:
-    resolution: {integrity: sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23:
-    resolution: {integrity: sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23:
-    resolution: {integrity: sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23:
-    resolution: {integrity: sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==}
-    engines: {node: '>= 20'}
-    dev: true
-
-  /@nomicfoundation/edr@0.12.0-next.23:
-    resolution: {integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==}
-    engines: {node: '>= 20'}
-    dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.23
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.23
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.23
-    dev: true
-
-  /@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3)(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.6):
-    resolution: {integrity: sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==}
-    peerDependencies:
-      '@nomicfoundation/hardhat-ethers': ^3.1.0
-      chai: ^4.2.0
-      ethers: ^6.14.0
-      hardhat: ^2.26.0
-    dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6)
-      '@types/chai-as-promised': 7.1.8
-      chai: 4.5.0
-      chai-as-promised: 7.1.2(chai@4.5.0)
-      deep-eql: 4.1.4
-      ethers: 6.16.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      ordinal: 1.0.3
-    dev: true
-
-  /@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.6):
-    resolution: {integrity: sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==}
-    peerDependencies:
-      ethers: ^6.14.0
-      hardhat: ^2.28.0
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      ethers: 6.16.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      lodash.isequal: 4.5.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3)(@nomicfoundation/hardhat-ignition@0.15.16)(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.6):
-    resolution: {integrity: sha512-io6Wrp1dUsJ94xEI3pw6qkPfhc9TFA+e6/+o16yQ8pvBTFMjgK5x8wIHKrrIHr9L3bkuTMtmDjyN4doqO2IqFQ==}
-    peerDependencies:
-      '@nomicfoundation/hardhat-ethers': ^3.1.0
-      '@nomicfoundation/hardhat-ignition': ^0.15.16
-      '@nomicfoundation/ignition-core': ^0.15.15
-      ethers: ^6.14.0
-      hardhat: ^2.26.0
-    dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3)(hardhat@2.28.6)
-      '@nomicfoundation/ignition-core': 0.15.15
-      ethers: 6.16.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-    dev: true
-
-  /@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3)(hardhat@2.28.6):
-    resolution: {integrity: sha512-T0JTnuib7QcpsWkHCPLT7Z6F483EjTdcdjb1e00jqS9zTGCPqinPB66LLtR/duDLdvgoiCVS6K8WxTQkA/xR1Q==}
-    peerDependencies:
-      '@nomicfoundation/hardhat-verify': ^2.1.0
-      hardhat: ^2.26.0
-    dependencies:
-      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.6)
-      '@nomicfoundation/ignition-core': 0.15.15
-      '@nomicfoundation/ignition-ui': 0.15.13
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      fs-extra: 10.1.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      json5: 2.2.3
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@2.28.6):
-    resolution: {integrity: sha512-p7HaUVDbLj7ikFivQVNhnfMHUBgiHYMwQWvGn9AriieuopGOELIrwj2KjyM2a6z70zai5YKO264Vwz+3UFJZPQ==}
-    peerDependencies:
-      hardhat: ^2.26.0
-    dependencies:
-      ethereumjs-util: 7.1.5
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-    dev: true
-
-  /@nomicfoundation/hardhat-toolbox@5.0.0(@nomicfoundation/hardhat-chai-matchers@2.1.2)(@nomicfoundation/hardhat-ethers@3.1.3)(@nomicfoundation/hardhat-ignition-ethers@0.15.17)(@nomicfoundation/hardhat-network-helpers@1.1.2)(@nomicfoundation/hardhat-verify@2.1.3)(@typechain/ethers-v6@0.5.1)(@typechain/hardhat@9.1.0)(@types/chai@4.3.20)(@types/mocha@10.0.10)(@types/node@20.19.17)(chai@4.5.0)(ethers@6.16.0)(hardhat-gas-reporter@2.3.0)(hardhat@2.28.6)(solidity-coverage@0.8.17)(ts-node@10.9.2)(typechain@8.3.2)(typescript@5.9.3):
-    resolution: {integrity: sha512-FnUtUC5PsakCbwiVNsqlXVIWG5JIb5CEZoSXbJUsEBun22Bivx2jhF1/q9iQbzuaGpJKFQyOhemPB2+XlEE6pQ==}
-    peerDependencies:
-      '@nomicfoundation/hardhat-chai-matchers': ^2.0.0
-      '@nomicfoundation/hardhat-ethers': ^3.0.0
-      '@nomicfoundation/hardhat-ignition-ethers': ^0.15.0
-      '@nomicfoundation/hardhat-network-helpers': ^1.0.0
-      '@nomicfoundation/hardhat-verify': ^2.0.0
-      '@typechain/ethers-v6': ^0.5.0
-      '@typechain/hardhat': ^9.0.0
-      '@types/chai': ^4.2.0
-      '@types/mocha': '>=9.1.0'
-      '@types/node': '>=18.0.0'
-      chai: ^4.2.0
-      ethers: ^6.4.0
-      hardhat: ^2.11.0
-      hardhat-gas-reporter: ^1.0.8
-      solidity-coverage: ^0.8.1
-      ts-node: '>=8.0.0'
-      typechain: ^8.3.0
-      typescript: '>=4.5.0'
-    dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.1.2(@nomicfoundation/hardhat-ethers@3.1.3)(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-ignition-ethers': 0.15.17(@nomicfoundation/hardhat-ethers@3.1.3)(@nomicfoundation/hardhat-ignition@0.15.16)(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.28.6)
-      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.6)
-      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2)(typescript@5.9.3)
-      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.16.0)(hardhat@2.28.6)(typechain@8.3.2)
-      '@types/chai': 4.3.20
-      '@types/mocha': 10.0.10
-      '@types/node': 20.19.17
-      chai: 4.5.0
-      ethers: 6.16.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      hardhat-gas-reporter: 2.3.0(hardhat@2.28.6)(typescript@5.9.3)
-      solidity-coverage: 0.8.17(hardhat@2.28.6)
-      ts-node: 10.9.2(@types/node@20.19.17)(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-      typescript: 5.9.3
-    dev: true
-
-  /@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.6):
-    resolution: {integrity: sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==}
-    peerDependencies:
-      hardhat: ^2.26.0
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/address': 5.8.0
-      cbor: 8.1.0
-      debug: 4.4.3(supports-color@8.1.1)
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      lodash.clonedeep: 4.5.0
-      picocolors: 1.1.1
-      semver: 6.3.1
-      table: 6.9.0
-      undici: 5.29.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@nomicfoundation/ignition-core@0.15.15:
-    resolution: {integrity: sha512-JdKFxYknTfOYtFXMN6iFJ1vALJPednuB+9p9OwGIRdoI6HYSh4ZBzyRURgyXtHFyaJ/SF9lBpsYV9/1zEpcYwg==}
-    dependencies:
-      '@ethersproject/address': 5.6.1
-      '@nomicfoundation/solidity-analyzer': 0.1.2
-      cbor: 9.0.2
-      debug: 4.4.3(supports-color@8.1.1)
-      ethers: 6.16.0
-      fs-extra: 10.1.0
-      immer: 10.0.2
-      lodash: 4.17.21
-      ndjson: 2.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@nomicfoundation/ignition-ui@0.15.13:
-    resolution: {integrity: sha512-HbTszdN1iDHCkUS9hLeooqnLEW2U45FaqFwFEYT8nIno2prFZhG+n68JEERjmfFCB5u0WgbuJwk3CgLoqtSL7Q==}
-    dev: true
-
-  /@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2:
-    resolution: {integrity: sha512-JaqcWPDZENCvm++lFFGjrDd8mxtf+CtLd2MiXvMNTBD33dContTZ9TWETwNFwg7JTJT5Q9HEecH7FA+HTSsIUw==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-darwin-x64@0.1.2:
-    resolution: {integrity: sha512-fZNmVztrSXC03e9RONBT+CiksSeYcxI1wlzqyr0L7hsQlK1fzV+f04g2JtQ1c/Fe74ZwdV6aQBdd6Uwl1052sw==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-linux-arm64-gnu@0.1.2:
-    resolution: {integrity: sha512-3d54oc+9ZVBuB6nbp8wHylk4xh0N0Gc+bk+/uJae+rUgbOBwQSfuGIbAZt1wBXs5REkSmynEGcqx6DutoK0tPA==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.1.2:
-    resolution: {integrity: sha512-iDJfR2qf55vgsg7BtJa7iPiFAsYf2d0Tv/0B+vhtnI16+wfQeTbP7teookbGvAo0eJo7aLLm0xfS/GTkvHIucA==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-linux-x64-gnu@0.1.2:
-    resolution: {integrity: sha512-9dlHMAt5/2cpWyuJ9fQNOUXFB/vgSFORg1jpjX1Mh9hJ/MfZXlDdHQ+DpFCs32Zk5pxRBb07yGvSHk9/fezL+g==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-linux-x64-musl@0.1.2:
-    resolution: {integrity: sha512-GzzVeeJob3lfrSlDKQw2bRJ8rBf6mEYaWY+gW0JnTDHINA0s2gPR4km5RLIj1xeZZOYz4zRw+AEeYgLRqB2NXg==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer-win32-x64-msvc@0.1.2:
-    resolution: {integrity: sha512-Fdjli4DCcFHb4Zgsz0uEJXZ2K7VEO+w5KVv7HmT7WO10iODdU9csC2az4jrhEsRtiR9Gfd74FlG0NYlw1BMdyA==}
-    engines: {node: '>= 12'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nomicfoundation/solidity-analyzer@0.1.2:
-    resolution: {integrity: sha512-q4n32/FNKIhQ3zQGGw5CvPF6GTvDCpYwIf7bEY/dZTZbgfDsHyjJwURxUJf3VQuuJj+fDIFl4+KkBVbw4Ef6jA==}
-    engines: {node: '>= 12'}
-    optionalDependencies:
-      '@nomicfoundation/solidity-analyzer-darwin-arm64': 0.1.2
-      '@nomicfoundation/solidity-analyzer-darwin-x64': 0.1.2
-      '@nomicfoundation/solidity-analyzer-linux-arm64-gnu': 0.1.2
-      '@nomicfoundation/solidity-analyzer-linux-arm64-musl': 0.1.2
-      '@nomicfoundation/solidity-analyzer-linux-x64-gnu': 0.1.2
-      '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
-      '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
-    dev: true
-
-  /@offchainlabs/upgrade-executor@1.1.0-beta.0:
-    resolution: {integrity: sha512-mpn6PHjH/KDDjNX0pXHEKdyv8m6DVGQiI2nGzQn0JbM1nOSHJpWx6fvfjtH7YxHJ6zBZTcsKkqGkFKDtCfoSLw==}
-    dependencies:
-      '@openzeppelin/contracts': 4.7.3
-      '@openzeppelin/contracts-upgradeable': 4.7.3
-    dev: true
-
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
     dev: false
-
-  /@openzeppelin/contracts-upgradeable@4.7.3:
-    resolution: {integrity: sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==}
-    dev: true
-
-  /@openzeppelin/contracts-upgradeable@4.9.6:
-    resolution: {integrity: sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==}
-    dev: true
-
-  /@openzeppelin/contracts@4.7.3:
-    resolution: {integrity: sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==}
-    dev: true
-
-  /@openzeppelin/contracts@4.8.3:
-    resolution: {integrity: sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==}
-    dev: true
-
-  /@openzeppelin/contracts@4.9.6:
-    resolution: {integrity: sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==}
-    dev: true
-
-  /@openzeppelin/contracts@5.0.2:
-    resolution: {integrity: sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==}
-    dev: true
-
-  /@openzeppelin/contracts@5.1.0:
-    resolution: {integrity: sha512-p1ULhl7BXzjjbha5aqst+QMLY+4/LCWADXOCsmLHRM77AqiPjnd9vvUN9sosUfhL9JGKpZ0TjEGxgvnizmWGSA==}
-    dev: true
-
-  /@openzeppelin/contracts@5.6.1:
-    resolution: {integrity: sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==}
-    dev: true
-
-  /@oven/bun-darwin-aarch64@1.3.10:
-    resolution: {integrity: sha512-PXgg5gqcS/rHwa1hF0JdM1y5TiyejVrMHoBmWY/DjtfYZoFTXie1RCFOkoG0b5diOOmUcuYarMpH7CSNTqwj+w==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-darwin-x64-baseline@1.3.10:
-    resolution: {integrity: sha512-w1gaTlqU0IJCmJ1X+PGHkdNU1n8Gemx5YKkjhkJIguvFINXEBB5U1KG82QsT65Tk4KyNMfbLTlmy4giAvUoKfA==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-darwin-x64@1.3.10:
-    resolution: {integrity: sha512-Nhssuh7GBpP5PiDSOl3+qnoIG7PJo+ec2oomDevnl9pRY6x6aD2gRt0JE+uf+A8Om2D6gjeHCxjEdrw5ZHE8mA==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-aarch64-musl@1.3.10:
-    resolution: {integrity: sha512-Ui5pAgM7JE9MzHokF0VglRMkbak3lTisY4Mf1AZutPACXWgKJC5aGrgnHBfkl7QS6fEeYb0juy1q4eRznRHOsw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-aarch64@1.3.10:
-    resolution: {integrity: sha512-OUgPHfL6+PM2Q+tFZjcaycN3D7gdQdYlWnwMI31DXZKY1r4HINWk9aEz9t/rNaHg65edwNrt7dsv9TF7xK8xIA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-x64-baseline@1.3.10:
-    resolution: {integrity: sha512-oqvMDYpX6dGJO03HgO5bXuccEsH3qbdO3MaAiAlO4CfkBPLUXz3N0DDElg5hz0L6ktdDVKbQVE5lfe+LAUISQg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-x64-musl-baseline@1.3.10:
-    resolution: {integrity: sha512-/hOZ6S1VsTX6vtbhWVL9aAnOrdpuO54mAGUWpTdMz7dFG5UBZ/VUEiK0pBkq9A1rlBk0GeD/6Y4NBFl8Ha7cRA==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-x64-musl@1.3.10:
-    resolution: {integrity: sha512-poVXvOShekbexHq45b4MH/mRjQKwACAC8lHp3Tz/hEDuz0/20oncqScnmKwzhBPEpqJvydXficXfBYuSim8opw==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-linux-x64@1.3.10:
-    resolution: {integrity: sha512-bzUgYj/PIZziB/ZesIP9HUyfvh6Vlf3od+TrbTTyVEuCSMKzDPQVW/yEbRp0tcHO3alwiEXwJDrWrHAguXlgiQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-windows-aarch64@1.3.10:
-    resolution: {integrity: sha512-GXbz2swvN2DLw2dXZFeedMxSJtI64xQ9xp9Eg7Hjejg6mS2E4dP1xoQ2yAo2aZPi/2OBPAVaGzppI2q20XumHA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-windows-x64-baseline@1.3.10:
-    resolution: {integrity: sha512-gh3UAHbUdDUG6fhLc1Csa4IGdtghue6U8oAIXWnUqawp6lwb3gOCRvp25IUnLF5vUHtgfMxuEUYV7YA2WxVutw==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@oven/bun-windows-x64@1.3.10:
-    resolution: {integrity: sha512-qaS1In3yfC/Z/IGQriVmF8GWwKuNqiw7feTSJWaQhH5IbL6ENR+4wGNPniZSJFaM/SKUO0e/YCRdoVBvgU4C1g==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
     optional: true
-
-  /@protobuf-ts/grpcweb-transport@2.11.1:
-    resolution: {integrity: sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==}
-    dependencies:
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-    dev: false
-
-  /@protobuf-ts/runtime-rpc@2.11.1:
-    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
-    dependencies:
-      '@protobuf-ts/runtime': 2.11.1
-    dev: false
-
-  /@protobuf-ts/runtime@2.11.1:
-    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
-    dev: false
 
   /@radix-ui/number@1.1.1:
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6396,6 +4784,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.57.1:
@@ -6403,6 +4792,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.57.1:
@@ -6410,6 +4800,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.57.1:
@@ -6417,6 +4808,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.57.1:
@@ -6424,6 +4816,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.57.1:
@@ -6431,6 +4824,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.57.1:
@@ -6438,6 +4832,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.57.1:
@@ -6445,6 +4840,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.57.1:
@@ -6452,6 +4848,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.57.1:
@@ -6459,6 +4856,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-loong64-gnu@4.57.1:
@@ -6466,6 +4864,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-loong64-musl@4.57.1:
@@ -6473,6 +4872,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-ppc64-gnu@4.57.1:
@@ -6480,6 +4880,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-ppc64-musl@4.57.1:
@@ -6487,6 +4888,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.57.1:
@@ -6494,6 +4896,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-musl@4.57.1:
@@ -6501,6 +4904,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.57.1:
@@ -6508,6 +4912,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.57.1:
@@ -6515,6 +4920,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.57.1:
@@ -6522,6 +4928,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-openbsd-x64@4.57.1:
@@ -6529,6 +4936,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-openharmony-arm64@4.57.1:
@@ -6536,6 +4944,7 @@ packages:
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.57.1:
@@ -6543,6 +4952,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.57.1:
@@ -6550,6 +4960,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-gnu@4.57.1:
@@ -6557,6 +4968,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.57.1:
@@ -6564,65 +4976,12 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
-
-  /@scroll-tech/contracts@2.0.0:
-    resolution: {integrity: sha512-O8sVaA/bVKH/mp+bBfUjZ/vYr5mdBExCpKRLre4r9TbXTtiaY9Uo5xU8dcG3weLxyK0BZqDTP2aCNp4Q0f7SeA==}
-    dev: true
-
-  /@scure/base@1.1.9:
-    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
-    dev: true
-
-  /@scure/base@1.2.6:
-    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
-
-  /@scure/bip32@1.1.5:
-    resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
-    dependencies:
-      '@noble/hashes': 1.2.0
-      '@noble/secp256k1': 1.7.1
-      '@scure/base': 1.1.9
-    dev: true
-
-  /@scure/bip32@1.4.0:
-    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
-    dependencies:
-      '@noble/curves': 1.4.2
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.9
-    dev: true
-
-  /@scure/bip32@1.7.0:
-    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-
-  /@scure/bip39@1.1.1:
-    resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
-    dependencies:
-      '@noble/hashes': 1.2.0
-      '@scure/base': 1.1.9
-    dev: true
-
-  /@scure/bip39@1.3.0:
-    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
-    dependencies:
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.9
-    dev: true
-
-  /@scure/bip39@1.6.0:
-    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
 
   /@secretlint/config-creator@10.2.2:
     resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
@@ -6639,7 +4998,7 @@ packages:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       rc-config-loader: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -6651,7 +5010,7 @@ packages:
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6667,7 +5026,7 @@ packages:
       '@textlint/module-interop': 15.5.1
       '@textlint/types': 15.5.1
       chalk: 5.6.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       pluralize: 8.0.0
       strip-ansi: 7.1.2
       table: 6.9.0
@@ -6686,7 +5045,7 @@ packages:
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -6731,169 +5090,9 @@ packages:
     engines: {node: '>=20.0.0'}
     dev: true
 
-  /@sentry/core@5.30.0:
-    resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/hub': 5.30.0
-      '@sentry/minimal': 5.30.0
-      '@sentry/types': 5.30.0
-      '@sentry/utils': 5.30.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/hub@5.30.0:
-    resolution: {integrity: sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/types': 5.30.0
-      '@sentry/utils': 5.30.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/minimal@5.30.0:
-    resolution: {integrity: sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/hub': 5.30.0
-      '@sentry/types': 5.30.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/node@5.30.0:
-    resolution: {integrity: sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/core': 5.30.0
-      '@sentry/hub': 5.30.0
-      '@sentry/tracing': 5.30.0
-      '@sentry/types': 5.30.0
-      '@sentry/utils': 5.30.0
-      cookie: 0.4.2
-      https-proxy-agent: 5.0.1
-      lru_map: 0.3.3
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@sentry/tracing@5.30.0:
-    resolution: {integrity: sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/hub': 5.30.0
-      '@sentry/minimal': 5.30.0
-      '@sentry/types': 5.30.0
-      '@sentry/utils': 5.30.0
-      tslib: 1.14.1
-    dev: true
-
-  /@sentry/types@5.30.0:
-    resolution: {integrity: sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /@sentry/utils@5.30.0:
-    resolution: {integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==}
-    engines: {node: '>=6'}
-    dependencies:
-      '@sentry/types': 5.30.0
-      tslib: 1.14.1
-    dev: true
-
   /@sindresorhus/merge-streams@2.3.0:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
-    dev: true
-
-  /@solana/buffer-layout@4.0.1:
-    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
-    engines: {node: '>=5.10'}
-    dependencies:
-      buffer: 6.0.3
-    dev: false
-
-  /@solana/codecs-core@2.3.0(typescript@5.9.3):
-    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-    dependencies:
-      '@solana/errors': 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    dev: false
-
-  /@solana/codecs-numbers@2.3.0(typescript@5.9.3):
-    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-    dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
-      '@solana/errors': 2.3.0(typescript@5.9.3)
-      typescript: 5.9.3
-    dev: false
-
-  /@solana/errors@2.3.0(typescript@5.9.3):
-    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.3.3'
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.3
-      typescript: 5.9.3
-    dev: false
-
-  /@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4):
-    resolution: {integrity: sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@solana/web3.js': ^1.98.0
-    dependencies:
-      '@solana/wallet-standard-features': 1.3.0
-      '@solana/web3.js': 1.98.4(typescript@5.9.3)
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      eventemitter3: 5.0.4
-    dev: false
-
-  /@solana/wallet-standard-features@1.3.0:
-    resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-    dev: false
-
-  /@solana/web3.js@1.98.4(typescript@5.9.3):
-    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
-      agentkeepalive: 4.6.0
-      bn.js: 5.2.3
-      borsh: 0.7.0
-      bs58: 4.0.1
-      buffer: 6.0.3
-      fast-stable-stringify: 1.0.0
-      jayson: 4.3.0
-      node-fetch: 2.7.0
-      rpc-websockets: 9.3.5
-      superstruct: 2.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-    dev: false
-
-  /@solidity-parser/parser@0.20.2:
-    resolution: {integrity: sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==}
     dev: true
 
   /@standard-schema/spec@1.0.0:
@@ -7082,7 +5281,7 @@ packages:
       '@textlint/resolver': 15.5.1
       '@textlint/types': 15.5.1
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       js-yaml: 4.1.1
       lodash: 4.17.21
       pluralize: 2.0.0
@@ -7176,56 +5375,11 @@ packages:
     dev: true
     optional: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2)(typescript@5.9.3):
-    resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
-    peerDependencies:
-      ethers: 6.x
-      typechain: ^8.3.2
-      typescript: '>=4.7.0'
-    dependencies:
-      ethers: 6.16.0
-      lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-      typescript: 5.9.3
-    dev: true
-
-  /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@6.16.0)(hardhat@2.28.6)(typechain@8.3.2):
-    resolution: {integrity: sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==}
-    peerDependencies:
-      '@typechain/ethers-v6': ^0.5.1
-      ethers: ^6.1.0
-      hardhat: ^2.9.9
-      typechain: ^8.3.2
-    dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2)(typescript@5.9.3)
-      ethers: 6.16.0
-      fs-extra: 9.1.0
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      typechain: 8.3.2(typescript@5.9.3)
-    dev: true
-
-  /@types/bn.js@5.2.0:
-    resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
-    dependencies:
-      '@types/node': 20.19.17
-    dev: true
-
   /@types/body-parser@1.19.6:
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 20.19.17
-    dev: true
-
-  /@types/chai-as-promised@7.1.8:
-    resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
-    dependencies:
-      '@types/chai': 4.3.20
-    dev: true
-
-  /@types/chai@4.3.20:
-    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
     dev: true
 
   /@types/chrome@0.1.36:
@@ -7246,6 +5400,7 @@ packages:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 20.19.17
+    dev: true
 
   /@types/cors@2.8.19:
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -7354,10 +5509,6 @@ packages:
       minimatch: 9.0.6
     dev: true
 
-  /@types/mocha@10.0.10:
-    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
-    dev: true
-
   /@types/ms@2.1.0:
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
     dev: false
@@ -7371,6 +5522,7 @@ packages:
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    dev: true
 
   /@types/node@18.19.130:
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -7387,11 +5539,7 @@ packages:
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
     dependencies:
       undici-types: 6.21.0
-
-  /@types/node@22.7.5:
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
-    dependencies:
-      undici-types: 6.19.8
+    dev: true
 
   /@types/node@25.3.0:
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
@@ -7409,12 +5557,6 @@ packages:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
     dev: true
 
-  /@types/pbkdf2@3.1.2:
-    resolution: {integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==}
-    dependencies:
-      '@types/node': 20.19.17
-    dev: true
-
   /@types/pg@8.11.6:
     resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
     dependencies:
@@ -7426,10 +5568,6 @@ packages:
   /@types/phoenix@1.6.6:
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
     dev: false
-
-  /@types/prettier@2.7.3:
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
-    dev: true
 
   /@types/qs@6.14.0:
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -7459,12 +5597,6 @@ packages:
 
   /@types/sarif@2.1.7:
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
-    dev: true
-
-  /@types/secp256k1@4.0.7:
-    resolution: {integrity: sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==}
-    dependencies:
-      '@types/node': 20.19.17
     dev: true
 
   /@types/send@1.2.1:
@@ -7502,19 +5634,9 @@ packages:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
     dev: false
 
-  /@types/uuid@10.0.0:
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-    dev: false
-
   /@types/vscode@1.109.0:
     resolution: {integrity: sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==}
     dev: true
-
-  /@types/ws@7.4.7:
-    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
-    dependencies:
-      '@types/node': 20.19.17
-    dev: false
 
   /@types/ws@8.18.1:
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -7578,7 +5700,7 @@ packages:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -7596,7 +5718,7 @@ packages:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7611,7 +5733,7 @@ packages:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -7625,7 +5747,7 @@ packages:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7667,7 +5789,7 @@ packages:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2)(typescript@5.9.2)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2
       ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -7685,7 +5807,7 @@ packages:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -7708,7 +5830,7 @@ packages:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 9.0.6
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -7728,7 +5850,7 @@ packages:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 9.0.6
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -7790,10 +5912,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@ungap/structured-clone@1.2.0:
-    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: false
 
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -8241,73 +6359,6 @@ packages:
     resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
     dev: false
 
-  /@wallet-standard/app@1.1.0:
-    resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-    dev: false
-
-  /@wallet-standard/base@1.1.0:
-    resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
-    engines: {node: '>=16'}
-    dev: false
-
-  /@wallet-standard/core@1.1.1:
-    resolution: {integrity: sha512-5Xmjc6+Oe0hcPfVc5n8F77NVLwx1JVAoCVgQpLyv/43/bhtIif+Gx3WUrDlaSDoM8i2kA2xd6YoFbHCxs+e0zA==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/errors': 0.1.1
-      '@wallet-standard/features': 1.1.0
-      '@wallet-standard/wallet': 1.1.0
-    dev: false
-
-  /@wallet-standard/errors@0.1.1:
-    resolution: {integrity: sha512-V8Ju1Wvol8i/VDyQOHhjhxmMVwmKiwyxUZBnHhtiPZJTWY0U/Shb2iEWyGngYEbAkp2sGTmEeNX1tVyGR7PqNw==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      chalk: 5.6.2
-      commander: 13.1.0
-    dev: false
-
-  /@wallet-standard/features@1.1.0:
-    resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-    dev: false
-
-  /@wallet-standard/wallet@1.1.0:
-    resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-    dev: false
-
-  /@yarnpkg/lockfile@1.1.0:
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-    dev: true
-
-  /abbrev@1.0.9:
-    resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
-    dev: true
-
-  /abitype@1.2.3(typescript@5.9.3):
-    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.9.3
-
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -8350,31 +6401,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  /adm-zip@0.4.16:
-    resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
-    engines: {node: '>=0.3.0'}
-    dev: true
-
-  /adze@2.3.0:
-    resolution: {integrity: sha512-c5I7uXn5jZ075LbW0lhkmllq4OLQsLHbEV63MbykOQr/VPIOdTgbxGH4QoXHqakAUO3rUSEmURd5eM9GgpJB6g==}
-    engines: {node: '>=18.19.0'}
-    dependencies:
-      '@ungap/structured-clone': 1.2.0
-      picocolors: 1.1.1
-    dev: false
-
-  /aes-js@4.0.0-beta.5:
-    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
-
-  /agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -8479,19 +6505,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  /amdefine@1.0.1:
-    resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
-    engines: {node: '>=0.4.2'}
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /ansi-align@3.0.1:
-    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
-    dependencies:
-      string-width: 4.2.3
-    dev: true
-
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -8531,11 +6544,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-
-  /ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
-    dev: false
 
   /ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -8577,16 +6585,6 @@ packages:
   /aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
-
-  /array-back@3.1.0:
-    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /array-back@4.0.2:
-    resolution: {integrity: sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==}
-    engines: {node: '>=8'}
-    dev: true
 
   /array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -8688,18 +6686,6 @@ packages:
       is-array-buffer: 3.0.5
     dev: true
 
-  /asn1.js@4.10.1:
-    resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
-    dependencies:
-      bn.js: 4.12.3
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-    dev: false
-
-  /assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-    dev: true
-
   /assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -8732,17 +6718,8 @@ packages:
       retry: 0.13.1
     dev: false
 
-  /async@1.5.2:
-    resolution: {integrity: sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==}
-    dev: true
-
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  /at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
-    dev: true
 
   /autoprefixer@10.4.21(postcss@8.5.6):
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
@@ -8764,20 +6741,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       possible-typed-array-names: 1.1.0
+    dev: true
 
   /axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
-    dev: true
-
-  /axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /axobject-query@4.1.0:
@@ -8805,18 +6773,10 @@ packages:
     dependencies:
       jackspeak: 4.2.3
 
-  /base-x@3.0.11:
-    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
-    dependencies:
-      safe-buffer: 5.2.1
-
-  /base-x@5.0.1:
-    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
-    dev: false
-
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     requiresBuild: true
+    dev: true
 
   /baseline-browser-mapping@2.9.12:
     resolution: {integrity: sha512-Mij6Lij93pTAIsSYy5cyBQ975Qh9uLEc5rwGTpomiZeXZL9yIS6uORJakb3ScHgfs0serMMfIbXzokPMuEiRyw==}
@@ -8826,14 +6786,6 @@ packages:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
     dev: true
-
-  /bech32@1.1.4:
-    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
-    dev: true
-
-  /bech32@2.0.0:
-    resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
-    dev: false
 
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -8853,29 +6805,6 @@ packages:
       editions: 6.22.0
     dev: true
 
-  /bip174@3.0.0:
-    resolution: {integrity: sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      uint8array-tools: 0.0.9
-      varuint-bitcoin: 2.0.0
-    dev: false
-
-  /bitcoinjs-lib@7.0.1(typescript@5.9.3):
-    resolution: {integrity: sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bech32: 2.0.0
-      bip174: 3.0.0
-      bs58check: 4.0.0
-      uint8array-tools: 0.0.9
-      valibot: 1.2.0(typescript@5.9.3)
-      varuint-bitcoin: 2.0.0
-    transitivePeerDependencies:
-      - typescript
-    dev: false
-
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -8883,20 +6812,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
     dev: true
-
-  /blakejs@1.2.1:
-    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
-    dev: true
-
-  /bn.js@4.11.6:
-    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
-    dev: true
-
-  /bn.js@4.12.3:
-    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
-
-  /bn.js@5.2.3:
-    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   /body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
@@ -8924,7 +6839,7 @@ packages:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -8939,30 +6854,8 @@ packages:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
 
-  /borsh@0.7.0:
-    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
-    dependencies:
-      bn.js: 5.2.3
-      bs58: 4.0.1
-      text-encoding-utf-8: 1.0.2
-    dev: false
-
   /boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
-    dev: true
-
-  /boxen@5.1.2:
-    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 6.3.0
-      chalk: 4.1.2
-      cli-boxes: 2.2.1
-      string-width: 4.2.3
-      type-fest: 0.20.2
-      widest-line: 3.1.0
-      wrap-ansi: 7.0.0
     dev: true
 
   /brace-expansion@1.1.12:
@@ -8990,68 +6883,6 @@ packages:
     dependencies:
       fill-range: 7.1.1
 
-  /brorand@1.1.0:
-    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
-
-  /brotli-wasm@2.0.1:
-    resolution: {integrity: sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww==}
-    dev: true
-
-  /browser-stdout@1.3.1:
-    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
-    dev: true
-
-  /browserify-aes@1.2.0:
-    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
-    dependencies:
-      buffer-xor: 1.0.3
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      evp_bytestokey: 1.0.3
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  /browserify-cipher@1.0.1:
-    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
-    dependencies:
-      browserify-aes: 1.2.0
-      browserify-des: 1.0.2
-      evp_bytestokey: 1.0.3
-    dev: false
-
-  /browserify-des@1.0.2:
-    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
-    dependencies:
-      cipher-base: 1.0.7
-      des.js: 1.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-    dev: false
-
-  /browserify-rsa@4.1.1:
-    resolution: {integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      bn.js: 5.2.3
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-    dev: false
-
-  /browserify-sign@4.2.5:
-    resolution: {integrity: sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      bn.js: 5.2.3
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      elliptic: 6.6.1
-      inherits: 2.0.4
-      parse-asn1: 5.1.9
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-    dev: false
-
   /browserslist@4.26.2:
     resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -9063,32 +6894,6 @@ packages:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
-  /bs58@4.0.1:
-    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
-    dependencies:
-      base-x: 3.0.11
-
-  /bs58@6.0.0:
-    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
-    dependencies:
-      base-x: 5.0.1
-    dev: false
-
-  /bs58check@2.1.2:
-    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
-    dependencies:
-      bs58: 4.0.1
-      create-hash: 1.2.0
-      safe-buffer: 5.2.1
-    dev: true
-
-  /bs58check@4.0.0:
-    resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bs58: 6.0.0
-    dev: false
-
   /buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
@@ -9099,9 +6904,7 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  /buffer-xor@1.0.3:
-    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+    dev: true
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -9111,24 +6914,13 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
-
   /bufferutil@4.0.9:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.8.4
-
-  /bufio@1.2.3:
-    resolution: {integrity: sha512-5Tt66bRzYUSlVZatc0E92uDenreJ+DpTBmSAUwL4VSxJn3e6cUyYwx+PoqML0GRZatgA/VX8ybhxItF8InZgqA==}
-    engines: {node: '>=8.0.0'}
-    dev: true
+    dev: false
 
   /builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
@@ -9136,43 +6928,12 @@ packages:
       semver: 7.7.3
     dev: true
 
-  /bun@1.3.10:
-    resolution: {integrity: sha512-S/CXaXXIyA4CMjdMkYQ4T2YMqnAn4s0ysD3mlsY4bUiOCqGlv28zck4Wd4H4kpvbekx15S9mUeLQ7Uxd0tYTLA==}
-    cpu: [arm64, x64]
-    os: [darwin, linux, win32]
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@oven/bun-darwin-aarch64': 1.3.10
-      '@oven/bun-darwin-x64': 1.3.10
-      '@oven/bun-darwin-x64-baseline': 1.3.10
-      '@oven/bun-linux-aarch64': 1.3.10
-      '@oven/bun-linux-aarch64-musl': 1.3.10
-      '@oven/bun-linux-x64': 1.3.10
-      '@oven/bun-linux-x64-baseline': 1.3.10
-      '@oven/bun-linux-x64-musl': 1.3.10
-      '@oven/bun-linux-x64-musl-baseline': 1.3.10
-      '@oven/bun-windows-aarch64': 1.3.10
-      '@oven/bun-windows-x64': 1.3.10
-      '@oven/bun-windows-x64-baseline': 1.3.10
-    dev: false
-
   /bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
     dependencies:
       run-applescript: 7.1.0
     dev: true
-
-  /bundle-require@5.1.0(esbuild@0.25.12):
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
-    dependencies:
-      esbuild: 0.25.12
-      load-tsconfig: 0.2.5
-    dev: false
 
   /bundle-require@5.1.0(esbuild@0.27.3):
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -9187,10 +6948,12 @@ packages:
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -9207,6 +6970,7 @@ packages:
       es-define-property: 1.0.1
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
+    dev: true
 
   /call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
@@ -9231,55 +6995,15 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  /camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
-
   /caniuse-lite@1.0.30001743:
     resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
 
   /caniuse-lite@1.0.30001751:
     resolution: {integrity: sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==}
 
-  /cbor@8.1.0:
-    resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
-    engines: {node: '>=12.19'}
-    dependencies:
-      nofilter: 3.1.0
-    dev: true
-
-  /cbor@9.0.2:
-    resolution: {integrity: sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      nofilter: 3.1.0
-    dev: true
-
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: false
-
-  /chai-as-promised@7.1.2(chai@4.5.0):
-    resolution: {integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==}
-    peerDependencies:
-      chai: '>= 2.1.2 < 6'
-    dependencies:
-      chai: 4.5.0
-      check-error: 1.0.3
-    dev: true
-
-  /chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-    dev: true
 
   /chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -9380,16 +7104,6 @@ packages:
     resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
     dev: true
 
-  /charenc@0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-    dev: true
-
-  /check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
-
   /check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -9442,6 +7156,7 @@ packages:
     engines: {node: '>= 14.16.0'}
     dependencies:
       readdirp: 4.1.2
+    dev: true
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -9449,22 +7164,10 @@ packages:
     dev: true
     optional: true
 
-  /ci-info@2.0.0:
-    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
-    dev: true
-
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
     dev: true
-
-  /cipher-base@1.0.7:
-    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
 
   /class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -9474,11 +7177,6 @@ packages:
 
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /cli-boxes@2.2.1:
-    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
     engines: {node: '>=6'}
     dev: true
 
@@ -9494,15 +7192,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
-    engines: {node: 10.* || >= 12.*}
-    dependencies:
-      string-width: 4.2.3
-    optionalDependencies:
-      '@colors/colors': 1.5.0
-    dev: true
-
   /cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
@@ -9511,14 +7200,6 @@ packages:
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
-
-  /cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: true
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -9585,30 +7266,6 @@ packages:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: false
 
-  /command-exists@1.2.9:
-    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
-    dev: true
-
-  /command-line-args@5.2.1:
-    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      array-back: 3.1.0
-      find-replace: 3.0.0
-      lodash.camelcase: 4.3.0
-      typical: 4.0.0
-    dev: true
-
-  /command-line-usage@6.1.3:
-    resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      array-back: 4.0.2
-      chalk: 2.4.2
-      table-layout: 1.0.2
-      typical: 5.2.0
-    dev: true
-
   /commander@10.0.0:
     resolution: {integrity: sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==}
     engines: {node: '>=14'}
@@ -9618,28 +7275,9 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  /commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
-    dev: false
-
-  /commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
-    dev: false
-
-  /commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: false
-
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  /commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
-    dev: true
 
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -9674,16 +7312,12 @@ packages:
 
   /confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
 
   /consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  /console-table-printer@2.15.0:
-    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
-    dependencies:
-      simple-wcswidth: 1.1.2
-    dev: false
+    dev: true
 
   /constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -9721,11 +7355,6 @@ packages:
     engines: {node: '>=6.6.0'}
     dev: false
 
-  /cookie@0.4.2:
-    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -9741,9 +7370,6 @@ packages:
     requiresBuild: true
     dev: true
 
-  /core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
   /cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -9752,45 +7378,8 @@ packages:
       vary: 1.1.2
     dev: false
 
-  /create-ecdh@4.0.4:
-    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
-    dependencies:
-      bn.js: 4.12.3
-      elliptic: 6.6.1
-    dev: false
-
-  /create-hash@1.2.0:
-    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
-    dependencies:
-      cipher-base: 1.0.7
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.3
-      sha.js: 2.4.12
-
-  /create-hmac@1.1.7:
-    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
-    dependencies:
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      inherits: 2.0.4
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-    dev: true
-
-  /cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
     dev: true
 
   /cross-spawn@7.0.6:
@@ -9800,28 +7389,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  /crypt@0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
-    dev: true
-
-  /crypto-browserify@3.12.1:
-    resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      browserify-cipher: 1.0.1
-      browserify-sign: 4.2.5
-      create-ecdh: 4.0.4
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      diffie-hellman: 5.0.3
-      hash-base: 3.0.5
-      inherits: 2.0.4
-      pbkdf2: 3.1.5
-      public-encrypt: 4.0.3
-      randombytes: 2.1.0
-      randomfill: 1.0.4
-    dev: false
 
   /css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -9882,14 +7449,6 @@ packages:
       is-data-view: 1.0.2
     dev: true
 
-  /dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-    dev: true
-
-  /death@1.1.0:
-    resolution: {integrity: sha512-vsV6S4KVHvTGxbEcij7hkWRv0It+sGGWVOM67dQde/o5Xjnr+KmLjxWJii2uEObIrt1CcM9w0Yaovx+iOlIL+w==}
-    dev: true
-
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -9912,7 +7471,7 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.4.3(supports-color@8.1.1):
+  /debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -9922,17 +7481,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-      supports-color: 8.1.1
-
-  /decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  /decamelize@4.0.0:
-    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
-    engines: {node: '>=10'}
-    dev: true
 
   /decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -9948,13 +7496,6 @@ packages:
       mimic-response: 3.1.0
     dev: true
     optional: true
-
-  /deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
-    dependencies:
-      type-detect: 4.1.0
-    dev: true
 
   /deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -9997,6 +7538,7 @@ packages:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+    dev: true
 
   /define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -10035,11 +7577,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /delay@5.0.0:
-    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
-    engines: {node: '>=10'}
-    dev: false
-
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -10047,17 +7584,11 @@ packages:
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-    dev: false
-
-  /des.js@1.1.0:
-    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
     dev: false
 
   /destroy@1.2.0:
@@ -10100,25 +7631,6 @@ packages:
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
-    dev: true
-
-  /diff@5.2.2:
-    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
-    engines: {node: '>=0.3.1'}
-    dev: true
-
-  /diffie-hellman@5.0.3:
-    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
-    dependencies:
-      bn.js: 4.12.3
-      miller-rabin: 4.0.1
-      randombytes: 2.1.0
-    dev: false
-
-  /difflib@0.2.4:
-    resolution: {integrity: sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==}
-    dependencies:
-      heap: 0.2.7
     dev: true
 
   /dir-glob@3.0.1:
@@ -10183,11 +7695,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
-    engines: {node: '>=12'}
-    dev: false
-
   /drizzle-kit@0.25.0:
     resolution: {integrity: sha512-Rcf0nYCAKizwjWQCY+d3zytyuTbDb81NcaPor+8NebESlUz1+9W3uGl0+r9FhU4Qal5Zv9j/7neXCSCe7DHzjA==}
     hasBin: true
@@ -10199,18 +7706,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /drizzle-kit@0.31.9:
-    resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
-    hasBin: true
-    dependencies:
-      '@drizzle-team/brocli': 0.10.2
-      '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.25.12
-      esbuild-register: 3.6.0(esbuild@0.25.12)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /drizzle-orm@0.34.1(@types/react@19.2.10)(@vercel/postgres@0.10.0)(react@19.0.0):
     resolution: {integrity: sha512-t+zCwyWWt8xTqtYV4doE/xYmT7hpv1L8pQ66zddEz+3VWyedBBtctjMAp22mAJPfyWurRQXUJ1nrTtqLq+DqNA==}
@@ -10306,103 +7801,6 @@ packages:
       react: 19.0.0
     dev: false
 
-  /drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@neondatabase/serverless@1.0.2)(pg@8.19.0):
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
-    peerDependencies:
-      '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=4'
-      '@electric-sql/pglite': '>=0.2.0'
-      '@libsql/client': '>=0.10.0'
-      '@libsql/client-wasm': '>=0.10.0'
-      '@neondatabase/serverless': '>=0.10.0'
-      '@op-engineering/op-sqlite': '>=2'
-      '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1.13'
-      '@prisma/client': '*'
-      '@tidbcloud/serverless': '*'
-      '@types/better-sqlite3': '*'
-      '@types/pg': '*'
-      '@types/sql.js': '*'
-      '@upstash/redis': '>=1.34.7'
-      '@vercel/postgres': '>=0.8.0'
-      '@xata.io/client': '*'
-      better-sqlite3: '>=7'
-      bun-types: '*'
-      expo-sqlite: '>=14.0.0'
-      gel: '>=2'
-      knex: '*'
-      kysely: '*'
-      mysql2: '>=2'
-      pg: '>=8'
-      postgres: '>=3'
-      prisma: '*'
-      sql.js: '>=1'
-      sqlite3: '>=5'
-    peerDependenciesMeta:
-      '@aws-sdk/client-rds-data':
-        optional: true
-      '@cloudflare/workers-types':
-        optional: true
-      '@electric-sql/pglite':
-        optional: true
-      '@libsql/client':
-        optional: true
-      '@libsql/client-wasm':
-        optional: true
-      '@neondatabase/serverless':
-        optional: true
-      '@op-engineering/op-sqlite':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@planetscale/database':
-        optional: true
-      '@prisma/client':
-        optional: true
-      '@tidbcloud/serverless':
-        optional: true
-      '@types/better-sqlite3':
-        optional: true
-      '@types/pg':
-        optional: true
-      '@types/sql.js':
-        optional: true
-      '@upstash/redis':
-        optional: true
-      '@vercel/postgres':
-        optional: true
-      '@xata.io/client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      bun-types:
-        optional: true
-      expo-sqlite:
-        optional: true
-      gel:
-        optional: true
-      knex:
-        optional: true
-      kysely:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      postgres:
-        optional: true
-      prisma:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
-    dependencies:
-      '@electric-sql/pglite': 0.3.15
-      '@neondatabase/serverless': 1.0.2
-      pg: 8.19.0
-    dev: false
-
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -10433,17 +7831,6 @@ packages:
 
   /electron-to-chromium@1.5.222:
     resolution: {integrity: sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==}
-
-  /elliptic@6.6.1:
-    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   /embla-carousel-react@8.6.0(react@19.0.0):
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
@@ -10514,11 +7901,6 @@ packages:
   /entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
-
-  /env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-    dev: true
 
   /environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -10650,37 +8032,16 @@ packages:
       is-symbol: 1.1.1
     dev: true
 
-  /es6-promise@4.2.8:
-    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
-    dev: false
-
-  /es6-promisify@5.0.0:
-    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
-    dependencies:
-      es6-promise: 4.2.8
-    dev: false
-
   /esbuild-register@3.6.0(esbuild@0.19.12):
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       esbuild: 0.19.12
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /esbuild-register@3.6.0(esbuild@0.25.12):
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      esbuild: 0.25.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -10710,6 +8071,7 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+    dev: true
 
   /esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
@@ -10837,40 +8199,6 @@ packages:
       '@esbuild/win32-x64': 0.24.2
     dev: true
 
-  /esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-    dev: false
-
   /esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -10903,6 +8231,7 @@ packages:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+    dev: true
 
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -10920,19 +8249,6 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /escodegen@1.8.1:
-    resolution: {integrity: sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==}
-    engines: {node: '>=0.12.0'}
-    hasBin: true
-    dependencies:
-      esprima: 2.7.3
-      estraverse: 1.9.3
-      esutils: 2.0.3
-      optionator: 0.8.3
-    optionalDependencies:
-      source-map: 0.2.0
     dev: true
 
   /escodegen@2.1.0:
@@ -10998,7 +8314,7 @@ packages:
         optional: true
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.52.0)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       get-tsconfig: 4.13.0
@@ -11187,7 +8503,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -11243,7 +8559,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -11288,12 +8604,6 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /esprima@2.7.3:
-    resolution: {integrity: sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dev: true
-
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -11317,11 +8627,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
-    dev: true
-
-  /estraverse@1.9.3:
-    resolution: {integrity: sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /estraverse@5.3.0:
@@ -11353,98 +8658,9 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /ethereum-bloom-filters@1.2.0:
-    resolution: {integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==}
-    dependencies:
-      '@noble/hashes': 1.8.0
-    dev: true
-
-  /ethereum-cryptography@0.1.3:
-    resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
-    dependencies:
-      '@types/pbkdf2': 3.1.2
-      '@types/secp256k1': 4.0.7
-      blakejs: 1.2.1
-      browserify-aes: 1.2.0
-      bs58check: 2.1.2
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      hash.js: 1.1.7
-      keccak: 3.0.4
-      pbkdf2: 3.1.5
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-      scrypt-js: 3.0.1
-      secp256k1: 4.0.4
-      setimmediate: 1.0.5
-    dev: true
-
-  /ethereum-cryptography@1.2.0:
-    resolution: {integrity: sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==}
-    dependencies:
-      '@noble/hashes': 1.2.0
-      '@noble/secp256k1': 1.7.1
-      '@scure/bip32': 1.1.5
-      '@scure/bip39': 1.1.1
-    dev: true
-
-  /ethereum-cryptography@2.2.1:
-    resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
-    dependencies:
-      '@noble/curves': 1.4.2
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-    dev: true
-
-  /ethereumjs-util@7.1.5:
-    resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@types/bn.js': 5.2.0
-      bn.js: 5.2.3
-      create-hash: 1.2.0
-      ethereum-cryptography: 0.1.3
-      rlp: 2.2.7
-    dev: true
-
-  /ethers@6.16.0:
-    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  /ethjs-unit@0.1.6:
-    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
-    dependencies:
-      bn.js: 4.11.6
-      number-to-bn: 1.7.0
-    dev: true
-
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-    dev: false
-
-  /eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-    dev: false
-
-  /eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-
-  /eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
     dev: false
 
   /eventsource-parser@1.1.2:
@@ -11463,12 +8679,6 @@ packages:
     dependencies:
       eventsource-parser: 3.0.6
     dev: false
-
-  /evp_bytestokey@1.0.3:
-    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
-    dependencies:
-      md5.js: 1.3.5
-      safe-buffer: 5.2.1
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -11556,7 +8766,7 @@ packages:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -11606,11 +8816,6 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /eyes@0.1.8:
-    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
-    engines: {node: '> 0.1.90'}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -11654,15 +8859,6 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /fast-stable-stringify@1.0.0:
-    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
-    dev: false
-
   /fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -11693,6 +8889,7 @@ packages:
         optional: true
     dependencies:
       picomatch: 4.0.3
+    dev: true
 
   /figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -11740,7 +8937,7 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -11749,13 +8946,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /find-replace@3.0.0:
-    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      array-back: 3.1.0
-    dev: true
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -11773,18 +8963,13 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-    dependencies:
-      micromatch: 4.0.8
-    dev: true
-
   /fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
       rollup: 4.57.1
+    dev: true
 
   /flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -11803,25 +8988,8 @@ packages:
       keyv: 4.5.4
     dev: true
 
-  /flat@5.0.2:
-    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
-    hasBin: true
-    dev: true
-
   /flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-    dev: true
-
-  /follow-redirects@1.15.11(debug@4.4.3):
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
     dev: true
 
   /for-each@0.3.5:
@@ -11829,6 +8997,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       is-callable: 1.2.7
+    dev: true
 
   /foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -11868,10 +9037,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
     dev: false
-
-  /fp-ts@1.19.3:
-    resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
-    dev: true
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -11949,16 +9114,6 @@ packages:
       universalify: 0.1.2
     dev: true
 
-  /fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-    dev: true
-
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -11997,15 +9152,6 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  /get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
-
-  /get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-    dev: true
 
   /get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -12052,6 +9198,7 @@ packages:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: true
 
   /get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -12059,17 +9206,9 @@ packages:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /ghost-testrpc@0.0.2:
-    resolution: {integrity: sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==}
-    hasBin: true
-    dependencies:
-      chalk: 2.4.2
-      node-emoji: 1.11.0
     dev: true
 
   /github-from-package@0.0.0:
@@ -12115,38 +9254,6 @@ packages:
       path-scurry: 2.0.1
     dev: true
 
-  /glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-    dev: false
-
-  /glob@5.0.15:
-    resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
-  /glob@7.1.7:
-    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -12157,34 +9264,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
-
-  /glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
-    dev: true
-
-  /global-modules@2.0.0:
-    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
-    engines: {node: '>=6'}
-    dependencies:
-      global-prefix: 3.0.0
-    dev: true
-
-  /global-prefix@3.0.0:
-    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
-    engines: {node: '>=6'}
-    dependencies:
-      ini: 1.3.8
-      kind-of: 6.0.3
-      which: 1.3.1
     dev: true
 
   /globals@13.24.0:
@@ -12254,23 +9333,6 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  /gql.tada@1.9.0(graphql@16.13.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-1LMiA46dRs5oF7Qev6vMU32gmiNvM3+3nHoQZA9K9j2xQzH8xOAWnnJrLSbZOFHTSdFxqn86TL6beo1/7ja/aA==}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    dependencies:
-      '@0no-co/graphql.web': 1.2.0(graphql@16.13.0)
-      '@0no-co/graphqlsp': 1.15.2(graphql@16.13.0)(typescript@5.9.3)
-      '@gql.tada/cli-utils': 1.7.2(@0no-co/graphqlsp@1.15.2)(graphql@16.13.0)(typescript@5.9.3)
-      '@gql.tada/internal': 1.0.8(graphql@16.13.0)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@gql.tada/svelte-support'
-      - '@gql.tada/vue-support'
-      - graphql
-    dev: false
-
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -12286,11 +9348,6 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
-
-  /graphql@16.13.0:
-    resolution: {integrity: sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -12317,103 +9374,11 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
-
-  /hardhat-gas-reporter@2.3.0(hardhat@2.28.6)(typescript@5.9.3):
-    resolution: {integrity: sha512-ySdA+044xMQv1BlJu5CYXToHzMexKFfIWxlQTBNNoerx1x96+d15IMdN01iQZ/TJ7NH2V5sU73bz77LoS/PEVw==}
-    peerDependencies:
-      hardhat: ^2.16.0
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/units': 5.8.0
-      '@solidity-parser/parser': 0.20.2
-      axios: 1.13.6
-      brotli-wasm: 2.0.1
-      chalk: 4.1.2
-      cli-table3: 0.6.5
-      ethereum-cryptography: 2.2.1
-      glob: 10.4.5
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      jsonschema: 1.5.0
-      lodash: 4.17.21
-      markdown-table: 2.0.0
-      sha1: 1.1.1
-      viem: 2.46.3(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: true
-
-  /hardhat@2.28.6(ts-node@10.9.2)(typescript@5.9.3):
-    resolution: {integrity: sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==}
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@ethereumjs/util': 9.1.0
-      '@ethersproject/abi': 5.8.0
-      '@nomicfoundation/edr': 0.12.0-next.23
-      '@nomicfoundation/solidity-analyzer': 0.1.2
-      '@sentry/node': 5.30.0
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      boxen: 5.1.2
-      chokidar: 4.0.3
-      ci-info: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      find-up: 5.0.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      immutable: 4.3.7
-      io-ts: 1.10.4
-      json-stream-stringify: 3.1.6
-      keccak: 3.0.4
-      lodash: 4.17.21
-      micro-eth-signer: 0.14.0
-      mnemonist: 0.38.5
-      mocha: 10.8.2
-      p-map: 4.0.0
-      picocolors: 1.1.1
-      raw-body: 2.5.3
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.8.26(debug@4.4.3)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.15
-      ts-node: 10.9.2(@types/node@20.19.17)(typescript@5.9.3)
-      tsort: 0.0.1
-      typescript: 5.9.3
-      undici: 5.29.0
-      uuid: 8.3.2
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /has-flag@1.0.0:
-    resolution: {integrity: sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /has-flag@3.0.0:
@@ -12424,11 +9389,13 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
       es-define-property: 1.0.1
+    dev: true
 
   /has-proto@1.2.0:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
@@ -12446,28 +9413,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-
-  /hash-base@3.0.5:
-    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  /hash-base@3.1.2:
-    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
-  /hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -12541,20 +9486,11 @@ packages:
       space-separated-tokens: 1.1.5
     dev: false
 
-  /he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
-    dev: true
-
   /header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
     dependencies:
       no-case: 2.3.2
       upper-case: 1.1.3
-    dev: true
-
-  /heap@0.2.7:
-    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: true
 
   /helmet@8.1.0:
@@ -12579,13 +9515,6 @@ packages:
   /highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
     dev: false
-
-  /hmac-drbg@1.0.1:
-    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   /hono@4.12.3:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
@@ -12632,23 +9561,14 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+    dev: false
 
   /http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12658,7 +9578,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12706,6 +9626,7 @@ packages:
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     requiresBuild: true
+    dev: true
 
   /ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -12715,14 +9636,6 @@ packages:
   /ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
-    dev: true
-
-  /immer@10.0.2:
-    resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
-    dev: true
-
-  /immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
     dev: true
 
   /import-fresh@3.3.1:
@@ -12817,17 +9730,6 @@ packages:
       side-channel: 1.1.0
     dev: true
 
-  /interpret@1.4.0:
-    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
-    engines: {node: '>= 0.10'}
-    dev: true
-
-  /io-ts@1.10.4:
-    resolution: {integrity: sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==}
-    dependencies:
-      fp-ts: 1.19.3
-    dev: true
-
   /ip-address@10.0.1:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
@@ -12914,12 +9816,6 @@ packages:
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  /is-ci@2.0.0:
-    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
-    hasBin: true
-    dependencies:
-      ci-info: 2.0.0
     dev: true
 
   /is-core-module@2.16.1:
@@ -12952,12 +9848,6 @@ packages:
   /is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
     dev: false
-
-  /is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dev: true
 
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -13001,11 +9891,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-
-  /is-hex-prefixed@1.0.0:
-    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
-    dev: true
 
   /is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
@@ -13067,11 +9952,6 @@ packages:
 
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
     dev: true
 
@@ -13146,6 +10026,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       which-typed-array: 1.1.19
+    dev: true
 
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -13183,13 +10064,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-    dev: true
-
   /is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -13197,11 +10071,9 @@ packages:
       is-inside-container: 1.0.0
     dev: true
 
-  /isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: true
 
   /isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
@@ -13210,21 +10082,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  /isomorphic-ws@4.0.1(ws@7.5.10):
-    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
-    peerDependencies:
-      ws: '*'
-    dependencies:
-      ws: 7.5.10
-    dev: false
-
-  /isows@1.0.7(ws@8.18.3):
-    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
-    peerDependencies:
-      ws: '*'
-    dependencies:
-      ws: 8.18.3(bufferutil@4.0.9)
 
   /istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
@@ -13260,28 +10117,6 @@ packages:
     dependencies:
       '@isaacs/cliui': 9.0.0
 
-  /jayson@4.3.0:
-    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 12.20.55
-      '@types/ws': 7.4.7
-      commander: 2.20.3
-      delay: 5.0.0
-      es6-promisify: 5.0.0
-      eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10)
-      json-stringify-safe: 5.0.1
-      stream-json: 1.9.1
-      uuid: 8.3.2
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
-
   /jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -13293,16 +10128,7 @@ packages:
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-
-  /js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
     dev: true
-
-  /js-tiktoken@1.0.21:
-    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
-    dependencies:
-      base64-js: 1.5.1
-    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -13356,14 +10182,6 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json-stream-stringify@3.1.6:
-    resolution: {integrity: sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==}
-    engines: {node: '>=7.10.1'}
-    dev: true
-
-  /json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -13402,10 +10220,6 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
-
-  /jsonschema@1.5.0:
-    resolution: {integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==}
     dev: true
 
   /jsonwebtoken@9.0.3:
@@ -13449,16 +10263,6 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
-  /keccak@3.0.4:
-    resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
-    engines: {node: '>=10.0.0'}
-    requiresBuild: true
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.8.4
-      readable-stream: 3.6.2
-    dev: true
-
   /keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
     requiresBuild: true
@@ -13477,41 +10281,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-
-  /klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
-    dependencies:
-      graceful-fs: 4.2.11
-    dev: true
-
-  /kleur@3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /langsmith@0.5.7:
-    resolution: {integrity: sha512-FjYf2oBGMoSXnaT4SRaFguIiGJaonZ5VKWKJDPl9awLZjz2RkN29AcQWceecSINVzXzTvtRWPOjAWT+XggqNNg==}
-    peerDependencies:
-      '@opentelemetry/api': '*'
-      '@opentelemetry/exporter-trace-otlp-proto': '*'
-      '@opentelemetry/sdk-trace-base': '*'
-      openai: '*'
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/exporter-trace-otlp-proto':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      openai:
-        optional: true
-    dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 5.6.2
-      console-table-printer: 2.15.0
-      p-queue: 6.6.2
-      semver: 7.7.3
-      uuid: 10.0.0
     dev: false
 
   /language-subtag-registry@0.3.23:
@@ -13547,14 +10316,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /levn@0.3.0:
-    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-    dev: true
-
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -13579,6 +10340,7 @@ packages:
   /load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
 
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -13598,14 +10360,6 @@ packages:
       p-locate: 5.0.0
     dev: true
 
-  /lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-    dev: true
-
-  /lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-    dev: true
-
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
@@ -13617,11 +10371,6 @@ packages:
 
   /lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-    dev: true
-
-  /lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
     dev: true
 
   /lodash.isinteger@4.0.4:
@@ -13647,10 +10396,6 @@ packages:
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
     dev: true
-
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: false
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -13690,12 +10435,6 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
-
   /loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
     dev: true
@@ -13723,6 +10462,7 @@ packages:
   /lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
+    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -13739,10 +10479,6 @@ packages:
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
-    dev: true
-
-  /lru_map@0.3.3:
-    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
     dev: true
 
   /lucide-react@0.302.0(react@19.0.0):
@@ -13782,22 +10518,9 @@ packages:
       uc.micro: 2.1.0
     dev: true
 
-  /markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
-    dependencies:
-      repeat-string: 1.6.1
-    dev: true
-
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  /md5.js@1.3.5:
-    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
-    dependencies:
-      hash-base: 3.0.5
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   /mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
@@ -13918,11 +10641,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
-    dev: true
-
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
     dev: false
@@ -13944,24 +10662,6 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
     dev: false
-
-  /micro-eth-signer@0.14.0:
-    resolution: {integrity: sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==}
-    dependencies:
-      '@noble/curves': 1.8.2
-      '@noble/hashes': 1.7.2
-      micro-packed: 0.7.3
-    dev: true
-
-  /micro-ftch@0.3.1:
-    resolution: {integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==}
-    dev: true
-
-  /micro-packed@0.7.3:
-    resolution: {integrity: sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==}
-    dependencies:
-      '@scure/base': 1.2.6
-    dev: true
 
   /micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -14118,7 +10818,7 @@ packages:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14144,14 +10844,6 @@ packages:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-
-  /miller-rabin@4.0.1:
-    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
-    hasBin: true
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-    dev: false
 
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -14192,12 +10884,6 @@ packages:
     dev: true
     optional: true
 
-  /minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  /minimalistic-crypto-utils@1.0.1:
-    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
-
   /minimatch@10.2.1:
     resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
     engines: {node: 20 || >=22}
@@ -14205,24 +10891,10 @@ packages:
       brace-expansion: 5.0.2
     dev: true
 
-  /minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-    dependencies:
-      brace-expansion: 5.0.2
-    dev: false
-
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.12
-    dev: true
-
-  /minimatch@5.1.9:
-    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.2
     dev: true
 
   /minimatch@9.0.0:
@@ -14240,15 +10912,11 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
 
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  /minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: false
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -14263,12 +10931,6 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
   /mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
     dependencies:
@@ -14276,38 +10938,6 @@ packages:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
-
-  /mnemonist@0.38.5:
-    resolution: {integrity: sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==}
-    dependencies:
-      obliterator: 2.0.5
-    dev: true
-
-  /mocha@10.8.2:
-    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
-    engines: {node: '>= 14.0.0'}
-    hasBin: true
-    dependencies:
-      ansi-colors: 4.1.3
-      browser-stdout: 1.3.1
-      chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
-      diff: 5.2.2
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 8.1.0
-      he: 1.2.0
-      js-yaml: 4.1.1
-      log-symbols: 4.1.0
-      minimatch: 5.1.9
-      ms: 2.1.3
-      serialize-javascript: 6.0.2
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 6.5.1
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
-      yargs-unparser: 2.0.0
     dev: true
 
   /motion-dom@11.18.1:
@@ -14331,11 +10961,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  /mustache@4.2.0:
-    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
-    hasBin: true
-    dev: false
 
   /mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -14386,18 +11011,6 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /ndjson@2.0.0:
-    resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      json-stringify-safe: 5.0.1
-      minimist: 1.2.8
-      readable-stream: 3.6.2
-      split2: 3.2.2
-      through2: 4.0.2
-    dev: true
-
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -14415,6 +11028,7 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: true
 
   /netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
@@ -14465,10 +11079,6 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-    dev: true
-
   /no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
     dependencies:
@@ -14484,31 +11094,17 @@ packages:
     dev: true
     optional: true
 
-  /node-addon-api@2.0.2:
-    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
-    dev: true
-
   /node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
     requiresBuild: true
     dev: true
     optional: true
 
-  /node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
-    dev: true
-
   /node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
     dev: false
-
-  /node-emoji@1.11.0:
-    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
-    dependencies:
-      lodash: 4.17.21
-    dev: true
 
   /node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -14520,10 +11116,12 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: false
 
   /node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+    dev: false
 
   /node-plop@0.26.3:
     resolution: {integrity: sha512-Cov028YhBZ5aB7MdMWJEmwyBig43aGL5WT4vdoB28Oitau1zZAcHUn8Sgfk9HM33TqhtLJ9PlM/O0Mv+QpV/4Q==}
@@ -14542,12 +11140,6 @@ packages:
       resolve: 1.22.10
     dev: true
 
-  /node-readable-to-web-readable-stream@0.4.2:
-    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
@@ -14557,18 +11149,6 @@ packages:
     dependencies:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.3
-    dev: true
-
-  /nofilter@3.1.0:
-    resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
-    engines: {node: '>=12.19'}
-    dev: true
-
-  /nopt@3.0.6:
-    resolution: {integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==}
-    hasBin: true
-    dependencies:
-      abbrev: 1.0.9
     dev: true
 
   /normalize-package-data@6.0.2:
@@ -14599,14 +11179,6 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
-    dev: true
-
-  /number-to-bn@1.7.0:
-    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
-    dependencies:
-      bn.js: 4.11.6
-      strip-hex-prefix: 1.0.0
     dev: true
 
   /object-assign@4.1.1:
@@ -14677,10 +11249,6 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /obliterator@2.0.5:
-    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
-    dev: true
-
   /obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: false
@@ -14719,14 +11287,6 @@ packages:
       wsl-utils: 0.1.0
     dev: true
 
-  /open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
-    dev: true
-
   /openai@4.104.0(zod@3.25.76):
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
@@ -14750,18 +11310,6 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: false
-
-  /optionator@0.8.3:
-    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.3.0
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-      word-wrap: 1.2.5
-    dev: true
 
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -14804,10 +11352,6 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
-  /ordinal@1.0.3:
-    resolution: {integrity: sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==}
-    dev: true
-
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -14826,37 +11370,12 @@ packages:
       safe-push-apply: 1.0.0
     dev: true
 
-  /ox@0.12.4(typescript@5.9.3):
-    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
-      eventemitter3: 5.0.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
   /p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
     dependencies:
       p-map: 2.1.0
     dev: true
-
-  /p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
-    dev: false
 
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -14898,32 +11417,10 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
-  /p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      aggregate-error: 3.1.0
-    dev: true
-
   /p-map@7.0.4:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
     dev: true
-
-  /p-queue@6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      eventemitter3: 4.0.7
-      p-timeout: 3.2.0
-    dev: false
-
-  /p-timeout@3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-finally: 1.0.0
-    dev: false
 
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -14936,7 +11433,7 @@ packages:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -14975,17 +11472,6 @@ packages:
     dependencies:
       callsites: 3.1.0
     dev: true
-
-  /parse-asn1@5.1.9:
-    resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      asn1.js: 4.10.1
-      browserify-aes: 1.2.0
-      evp_bytestokey: 1.0.3
-      pbkdf2: 3.1.5
-      safe-buffer: 5.2.1
-    dev: false
 
   /parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
@@ -15056,27 +11542,6 @@ packages:
       upper-case-first: 1.1.2
     dev: true
 
-  /patch-package@6.5.1:
-    resolution: {integrity: sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==}
-    engines: {node: '>=10', npm: '>5'}
-    hasBin: true
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      cross-spawn: 6.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 9.1.0
-      is-ci: 2.0.0
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      rimraf: 2.7.1
-      semver: 5.7.2
-      slash: 2.0.0
-      tmp: 0.0.33
-      yaml: 1.10.2
-    dev: true
-
   /path-case@2.1.1:
     resolution: {integrity: sha512-Ou0N05MioItesaLr9q8TtHVWmJ6fxWdqKB2RohFmNWVyJ+2zeKIeDNWAN6B/Pe7wpzWChhZX6nONYmOnMeJQ/Q==}
     dependencies:
@@ -15091,11 +11556,6 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /path-key@2.0.1:
-    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
-    engines: {node: '>=4'}
     dev: true
 
   /path-key@3.1.1:
@@ -15119,14 +11579,6 @@ packages:
       lru-cache: 11.2.6
       minipass: 7.1.2
     dev: true
-
-  /path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
-    dependencies:
-      lru-cache: 11.2.6
-      minipass: 7.1.3
-    dev: false
 
   /path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -15152,9 +11604,6 @@ packages:
 
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  /pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
   /pathval@2.0.1:
@@ -15162,38 +11611,9 @@ packages:
     engines: {node: '>= 14.16'}
     dev: true
 
-  /pbkdf2@3.1.5:
-    resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-      to-buffer: 1.2.2
-
-  /pdfjs-dist@5.4.624:
-    resolution: {integrity: sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==}
-    engines: {node: '>=20.16.0 || >=22.3.0'}
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.95
-      node-readable-to-web-readable-stream: 0.4.2
-    dev: false
-
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
     dev: true
-
-  /pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /pg-connection-string@2.11.0:
-    resolution: {integrity: sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==}
-    dev: false
 
   /pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -15205,31 +11625,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /pg-pool@3.12.0(pg@8.19.0):
-    resolution: {integrity: sha512-eIJ0DES8BLaziFHW7VgJEBPi5hg3Nyng5iKpYtj3wbcAUV9A1wLgWiY7ajf/f/oO1wfxt83phXPY8Emztg7ITg==}
-    peerDependencies:
-      pg: '>=8.0'
-    dependencies:
-      pg: 8.19.0
-    dev: false
-
   /pg-protocol@1.10.3:
     resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
-    dev: false
-
-  /pg-protocol@1.12.0:
-    resolution: {integrity: sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==}
-    dev: false
-
-  /pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.1
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
     dev: false
 
   /pg-types@4.1.0:
@@ -15243,30 +11640,6 @@ packages:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
-    dev: false
-
-  /pg@8.19.0:
-    resolution: {integrity: sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==}
-    engines: {node: '>= 16.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-    dependencies:
-      pg-connection-string: 2.11.0
-      pg-pool: 3.12.0(pg@8.19.0)
-      pg-protocol: 1.12.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.3.0
-    dev: false
-
-  /pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-    dependencies:
-      split2: 4.2.0
     dev: false
 
   /picocolors@1.0.1:
@@ -15283,6 +11656,7 @@ packages:
   /picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+    dev: true
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -15308,6 +11682,7 @@ packages:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+    dev: true
 
   /plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -15330,13 +11705,10 @@ packages:
     engines: {node: '>=14.19.0'}
     dev: true
 
-  /poseidon-lite@0.2.1:
-    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
-    dev: false
-
   /possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /postcss-import@15.1.0(postcss@8.5.6):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -15395,6 +11767,7 @@ packages:
       lilconfig: 3.1.3
       postcss: 8.5.6
       tsx: 4.21.0
+    dev: true
 
   /postcss-nested@6.2.0(postcss@8.5.6):
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
@@ -15440,19 +11813,9 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  /postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-    dev: false
-
   /postgres-array@3.0.4:
     resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
     engines: {node: '>=12'}
-    dev: false
-
-  /postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /postgres-bytea@3.0.0:
@@ -15462,21 +11825,9 @@ packages:
       obuf: 1.1.2
     dev: false
 
-  /postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /postgres-date@2.1.0:
     resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
     engines: {node: '>=12'}
-    dev: false
-
-  /postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      xtend: 4.0.2
     dev: false
 
   /postgres-interval@3.0.0:
@@ -15509,11 +11860,6 @@ packages:
     dev: true
     optional: true
 
-  /prelude-ls@1.1.2:
-    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
-    engines: {node: '>= 0.8.0'}
-    dev: true
-
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -15540,17 +11886,6 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
     dev: false
-
-  /process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  /prompts@2.4.2:
-    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
-    engines: {node: '>= 6'}
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-    dev: true
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -15583,7 +11918,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -15597,17 +11932,6 @@ packages:
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
-
-  /public-encrypt@4.0.3:
-    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
-    dependencies:
-      bn.js: 4.12.3
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      parse-asn1: 5.1.9
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-    dev: false
 
   /pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -15626,6 +11950,7 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
 
   /qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -15645,18 +11970,6 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  /randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-    dependencies:
-      safe-buffer: 5.2.1
-
-  /randomfill@1.0.4:
-    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
-    dependencies:
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-    dev: false
-
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -15670,6 +11983,7 @@ packages:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+    dev: false
 
   /raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -15684,7 +11998,7 @@ packages:
   /rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -15848,17 +12162,6 @@ packages:
       mute-stream: 0.0.8
     dev: true
 
-  /readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -15878,24 +12181,6 @@ packages:
   /readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
-
-  /rechoir@0.6.2:
-    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      resolve: 1.22.11
-    dev: true
-
-  /recursive-readdir@2.2.3:
-    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      minimatch: 3.1.2
-    dev: true
-
-  /reduce-flatten@2.0.0:
-    resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
-    engines: {node: '>=6'}
     dev: true
 
   /reflect.getprototypeof@1.0.10:
@@ -15996,16 +12281,6 @@ packages:
       - supports-color
     dev: false
 
-  /repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
-    dev: true
-
-  /require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -16018,18 +12293,10 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  /resolve@1.1.7:
-    resolution: {integrity: sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==}
-    dev: true
-
-  /resolve@1.17.0:
-    resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
-    dependencies:
-      path-parse: 1.0.7
     dev: true
 
   /resolve@1.22.10:
@@ -16077,34 +12344,12 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-    dev: true
-
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3
-    dev: true
-
-  /ripemd160@2.0.3:
-    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
-
-  /rlp@2.2.7:
-    resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
-    hasBin: true
-    dependencies:
-      bn.js: 5.2.3
     dev: true
 
   /robot3@0.4.1:
@@ -16144,33 +12389,19 @@ packages:
       '@rollup/rollup-win32-x64-gnu': 4.57.1
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+    dev: true
 
   /router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /rpc-websockets@9.3.5:
-    resolution: {integrity: sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A==}
-    dependencies:
-      '@swc/helpers': 0.5.15
-      '@types/uuid': 10.0.0
-      '@types/ws': 8.18.1
-      buffer: 6.0.3
-      eventemitter3: 5.0.4
-      uuid: 11.1.0
-      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 6.0.6
     dev: false
 
   /run-applescript@7.1.0:
@@ -16212,9 +12443,6 @@ packages:
       isarray: 2.0.5
     dev: true
 
-  /safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -16243,42 +12471,8 @@ packages:
     engines: {node: '>=11.0.0'}
     dev: true
 
-  /sc-istanbul@0.4.6:
-    resolution: {integrity: sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==}
-    hasBin: true
-    dependencies:
-      abbrev: 1.0.9
-      async: 1.5.2
-      escodegen: 1.8.1
-      esprima: 2.7.3
-      glob: 5.0.15
-      handlebars: 4.7.8
-      js-yaml: 3.14.1
-      mkdirp: 0.5.6
-      nopt: 3.0.6
-      once: 1.4.0
-      resolve: 1.1.7
-      supports-color: 3.2.3
-      which: 1.3.1
-      wordwrap: 1.0.0
-    dev: true
-
   /scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
-
-  /scrypt-js@3.0.1:
-    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-    dev: true
-
-  /secp256k1@4.0.4:
-    resolution: {integrity: sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==}
-    engines: {node: '>=18.0.0'}
-    requiresBuild: true
-    dependencies:
-      elliptic: 6.6.1
-      node-addon-api: 5.1.0
-      node-gyp-build: 4.8.4
-    dev: true
 
   /secretlint@10.2.2:
     resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
@@ -16289,7 +12483,7 @@ packages:
       '@secretlint/formatter': 10.2.2
       '@secretlint/node': 10.2.2
       '@secretlint/profiler': 10.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       globby: 14.1.0
       read-pkg: 9.0.1
     transitivePeerDependencies:
@@ -16359,7 +12553,7 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -16379,12 +12573,6 @@ packages:
     dependencies:
       no-case: 2.3.2
       upper-case-first: 1.1.2
-    dev: true
-
-  /serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-    dependencies:
-      randombytes: 2.1.0
     dev: true
 
   /serve-static@1.16.3:
@@ -16421,6 +12609,7 @@ packages:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+    dev: true
 
   /set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
@@ -16441,28 +12630,9 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-    dev: true
-
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  /sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
-  /sha1@1.1.1:
-    resolution: {integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==}
-    dependencies:
-      charenc: 0.0.2
-      crypt: 0.0.2
-    dev: true
+    dev: false
 
   /sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -16500,37 +12670,15 @@ packages:
     dev: false
     optional: true
 
-  /shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      shebang-regex: 1.0.0
-    dev: true
-
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
 
-  /shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  /shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
-    dev: true
 
   /side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -16596,19 +12744,6 @@ packages:
     dev: true
     optional: true
 
-  /simple-wcswidth@1.1.2:
-    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
-    dev: false
-
-  /sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
-
-  /slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
-    dev: true
-
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -16644,7 +12779,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -16658,54 +12793,6 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /solady@0.0.182:
-    resolution: {integrity: sha512-FW6xo1akJoYpkXMzu58/56FcNU3HYYNamEbnFO3iSibXk0nSHo0DV2Gu/zI3FPg3So5CCX6IYli1TT1IWATnvg==}
-    dev: true
-
-  /solc@0.8.26(debug@4.4.3):
-    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    dependencies:
-      command-exists: 1.2.9
-      commander: 8.3.0
-      follow-redirects: 1.15.11(debug@4.4.3)
-      js-sha3: 0.8.0
-      memorystream: 0.3.1
-      semver: 5.7.2
-      tmp: 0.0.33
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /solidity-coverage@0.8.17(hardhat@2.28.6):
-    resolution: {integrity: sha512-5P8vnB6qVX9tt1MfuONtCTEaEGO/O4WuEidPHIAJjx4sktHHKhO3rFvnE0q8L30nWJPTrcqGQMT7jpE29B2qow==}
-    hasBin: true
-    peerDependencies:
-      hardhat: ^2.11.0
-    dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@solidity-parser/parser': 0.20.2
-      chalk: 2.4.2
-      death: 1.1.0
-      difflib: 0.2.4
-      fs-extra: 8.1.0
-      ghost-testrpc: 0.0.2
-      global-modules: 2.0.0
-      globby: 10.0.2
-      hardhat: 2.28.6(ts-node@10.9.2)(typescript@5.9.3)
-      jsonschema: 1.5.0
-      lodash: 4.17.21
-      mocha: 10.8.2
-      node-emoji: 1.11.0
-      pify: 4.0.1
-      recursive-readdir: 2.2.3
-      sc-istanbul: 0.4.6
-      semver: 7.7.3
-      shelljs: 0.8.5
-      web3-utils: 1.10.4
-    dev: true
-
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -16715,32 +12802,17 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-
-  /source-map@0.2.0:
-    resolution: {integrity: sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==}
-    engines: {node: '>=0.8.0'}
-    requiresBuild: true
-    dependencies:
-      amdefine: 1.0.1
     dev: true
-    optional: true
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
     dev: true
-
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
-    dependencies:
-      whatwg-url: 7.1.0
-    dev: false
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
@@ -16779,17 +12851,6 @@ packages:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
     dev: true
 
-  /split2@3.2.2:
-    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
-    dependencies:
-      readable-stream: 3.6.2
-    dev: true
-
-  /split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-    dev: false
-
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -16810,16 +12871,10 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /stacktrace-parser@0.1.11:
-    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
-    engines: {node: '>=6'}
-    dependencies:
-      type-fest: 0.7.1
-    dev: true
-
   /statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -16831,20 +12886,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-    dev: true
-
-  /stream-chain@2.2.5:
-    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
-    dev: false
-
-  /stream-json@1.9.1:
-    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
-    dependencies:
-      stream-chain: 2.2.5
-    dev: false
-
-  /string-format@2.0.0:
-    resolution: {integrity: sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==}
     dev: true
 
   /string-width@4.2.3:
@@ -16930,11 +12971,6 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-    dependencies:
-      safe-buffer: 5.1.2
-
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     requiresBuild: true
@@ -16974,13 +13010,6 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-    dev: true
-
-  /strip-hex-prefix@1.0.0:
-    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
-    engines: {node: '>=6.5.0', npm: '>=3'}
-    dependencies:
-      is-hex-prefixed: 1.0.0
     dev: true
 
   /strip-json-comments@2.0.1:
@@ -17043,18 +13072,6 @@ packages:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
-  /superstruct@2.0.2:
-    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
-    engines: {node: '>=14.0.0'}
-    dev: false
-
-  /supports-color@3.2.3:
-    resolution: {integrity: sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      has-flag: 1.0.0
-    dev: true
-
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -17068,12 +13085,6 @@ packages:
     dependencies:
       has-flag: 4.0.0
     dev: true
-
-  /supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      has-flag: 4.0.0
 
   /supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
@@ -17141,16 +13152,6 @@ packages:
   /tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
     dev: false
-
-  /table-layout@1.0.2:
-    resolution: {integrity: sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      array-back: 4.0.2
-      deep-extend: 0.6.0
-      typical: 5.2.0
-      wordwrapjs: 4.0.1
-    dev: true
 
   /table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -17241,10 +13242,6 @@ packages:
       supports-hyperlinks: 3.2.0
     dev: true
 
-  /text-encoding-utf-8@1.0.2:
-    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
-    dev: false
-
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -17272,12 +13269,6 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /through2@4.0.2:
-    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
-    dependencies:
-      readable-stream: 3.6.2
-    dev: true
-
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
@@ -17292,6 +13283,7 @@ packages:
 
   /tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
 
   /tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -17299,6 +13291,7 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+    dev: true
 
   /tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
@@ -17341,14 +13334,6 @@ packages:
     engines: {node: '>=14.14'}
     dev: true
 
-  /to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -17358,19 +13343,16 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+    dev: false
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-    dependencies:
-      punycode: 2.3.1
     dev: false
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+    dev: true
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -17394,24 +13376,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-    dependencies:
-      typescript: 5.9.3
-    dev: true
-
-  /ts-command-line-args@2.5.1:
-    resolution: {integrity: sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      command-line-args: 5.2.1
-      command-line-usage: 6.1.3
-      string-format: 2.0.0
-    dev: true
-
-  /ts-essentials@7.0.3(typescript@5.9.3):
-    resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
-    peerDependencies:
-      typescript: '>=3.7.0'
     dependencies:
       typescript: 5.9.3
     dev: true
@@ -17450,37 +13414,6 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.3):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.17
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
   /tsc-alias@1.8.16:
     resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
     engines: {node: '>=16.20.2'}
@@ -17508,60 +13441,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  /tsort@0.0.1:
-    resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
-    dev: true
-
-  /tsup@8.5.0(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.12)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
-      esbuild: 0.25.12
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)
-      resolve-from: 5.0.0
-      rollup: 4.57.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-    dev: false
 
   /tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -17586,7 +13467,7 @@ packages:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -17617,6 +13498,7 @@ packages:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -17691,23 +13573,11 @@ packages:
       turbo-windows-arm64: 2.7.3
     dev: true
 
-  /type-check@0.3.2:
-    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      prelude-ls: 1.1.2
-    dev: true
-
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
-    dev: true
-
-  /type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
     dev: true
 
   /type-fest@0.20.2:
@@ -17718,11 +13588,6 @@ packages:
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
-    dev: true
-
-  /type-fest@0.7.1:
-    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
-    engines: {node: '>=8'}
     dev: true
 
   /type-fest@4.41.0:
@@ -17747,27 +13612,6 @@ packages:
       mime-types: 3.0.2
     dev: false
 
-  /typechain@8.3.2(typescript@5.9.3):
-    resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=4.3.0'
-    dependencies:
-      '@types/prettier': 2.7.3
-      debug: 4.4.3(supports-color@8.1.1)
-      fs-extra: 7.0.1
-      glob: 7.1.7
-      js-sha3: 0.8.0
-      lodash: 4.17.21
-      mkdirp: 1.0.4
-      prettier: 2.8.8
-      ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -17775,6 +13619,7 @@ packages:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
+    dev: true
 
   /typed-array-byte-length@1.0.3:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
@@ -17864,39 +13709,21 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typical@4.0.0:
-    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /typical@5.2.0:
-    resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
     dev: true
 
   /ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+    dev: true
 
   /uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
+    dev: true
     optional: true
-
-  /uint8array-tools@0.0.8:
-    resolution: {integrity: sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==}
-    engines: {node: '>=14.0.0'}
-    dev: false
-
-  /uint8array-tools@0.0.9:
-    resolution: {integrity: sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==}
-    engines: {node: '>=14.0.0'}
-    dev: false
 
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -17916,21 +13743,11 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: false
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   /undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-    dev: true
-
-  /undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      '@fastify/busboy': 2.1.1
     dev: true
 
   /undici@6.23.0:
@@ -17963,11 +13780,6 @@ packages:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
-    dev: false
-
-  /unique-names-generator@4.7.1:
-    resolution: {integrity: sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==}
-    engines: {node: '>=8'}
     dev: false
 
   /unist-util-is@6.0.1:
@@ -18016,6 +13828,7 @@ packages:
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+    dev: false
 
   /unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -18120,18 +13933,6 @@ packages:
       react: 19.0.0
     dev: false
 
-  /utf-8-validate@6.0.6:
-    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
-    engines: {node: '>=6.14.2'}
-    requiresBuild: true
-    dependencies:
-      node-gyp-build: 4.8.4
-    dev: false
-
-  /utf8@3.0.0:
-    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
-    dev: true
-
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -18140,39 +13941,14 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: false
 
-  /uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-    dev: false
-
-  /uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-    dev: false
-
-  /uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
-    dev: false
-
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
-
-  /valibot@1.2.0(typescript@5.9.3):
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.9.3
-    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -18187,12 +13963,6 @@ packages:
     dependencies:
       builtins: 5.1.0
     dev: true
-
-  /varuint-bitcoin@2.0.0:
-    resolution: {integrity: sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==}
-    dependencies:
-      uint8array-tools: 0.0.8
-    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -18218,35 +13988,13 @@ packages:
       vfile-message: 4.0.3
     dev: false
 
-  /viem@2.46.3(typescript@5.9.3):
-    resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@5.9.3)
-      typescript: 5.9.3
-      ws: 8.18.3(bufferutil@4.0.9)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   /vite-node@2.1.9(@types/node@20.19.17):
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@20.19.17)
@@ -18268,7 +14016,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@22.19.11)
@@ -18396,7 +14144,7 @@ packages:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 1.1.2
@@ -18454,7 +14202,7 @@ packages:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 1.1.2
@@ -18505,25 +14253,8 @@ packages:
     engines: {node: '>= 14'}
     dev: false
 
-  /web3-utils@1.10.4:
-    resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@ethereumjs/util': 8.1.0
-      bn.js: 5.2.3
-      ethereum-bloom-filters: 1.2.0
-      ethereum-cryptography: 2.2.1
-      ethjs-unit: 0.1.6
-      number-to-bn: 1.7.0
-      randombytes: 2.1.0
-      utf8: 3.0.0
-    dev: true
-
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: false
 
   /whatwg-encoding@3.1.1:
@@ -18544,13 +14275,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
     dev: false
 
   /which-boxed-primitive@1.1.1:
@@ -18604,12 +14328,6 @@ packages:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-
-  /which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
-    dependencies:
-      isexe: 2.0.0
     dev: true
 
   /which@2.0.2:
@@ -18628,13 +14346,6 @@ packages:
       stackback: 0.0.2
     dev: true
 
-  /widest-line@3.1.0:
-    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
-    engines: {node: '>=8'}
-    dependencies:
-      string-width: 4.2.3
-    dev: true
-
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -18642,17 +14353,6 @@ packages:
 
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  /wordwrapjs@4.0.1:
-    resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      reduce-flatten: 2.0.0
-      typical: 5.2.0
-    dev: true
-
-  /workerpool@6.5.1:
-    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
     dev: true
 
   /wrap-ansi@7.0.0:
@@ -18674,43 +14374,6 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  /ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  /ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  /ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
-
   /ws@8.18.3(bufferutil@4.0.9):
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -18724,21 +14387,6 @@ packages:
         optional: true
     dependencies:
       bufferutil: 4.0.9
-
-  /ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.6):
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 6.0.6
     dev: false
 
   /wsl-utils@0.1.0:
@@ -18766,11 +14414,6 @@ packages:
     engines: {node: '>=0.4'}
     dev: false
 
-  /y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-    dev: true
-
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -18778,43 +14421,10 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  /yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /yargs-unparser@2.0.0:
-    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
-    engines: {node: '>=10'}
-    dependencies:
-      camelcase: 6.3.0
-      decamelize: 4.0.0
-      flat: 5.0.2
-      is-plain-obj: 2.1.0
-    dev: true
-
-  /yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-    dev: true
 
   /yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -18863,10 +14473,6 @@ packages:
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  /zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-    dev: false
-
   /zustand@5.0.10(@types/react@19.2.10)(react@19.0.0):
     resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
     engines: {node: '>=12.20.0'}
@@ -18889,33 +14495,6 @@ packages:
       react: 19.0.0
     dev: false
 
-  /zustand@5.0.11(react@19.0.0):
-    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@types/react': ^19.0.0
-      immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-      use-sync-external-store:
-        optional: true
-    dependencies:
-      react: 19.0.0
-    dev: false
-
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
-
-  github.com/matter-labs/era-contracts/446d391d34bdb48255d5f8fef8a8248925fc98b9:
-    resolution: {tarball: https://codeload.github.com/matter-labs/era-contracts/tar.gz/446d391d34bdb48255d5f8fef8a8248925fc98b9}
-    name: era-contracts
-    version: 0.1.0
-    dev: true


### PR DESCRIPTION
## What this adds

A reusable **Monster System** for Arcanea plus its flagship: **Nethyssa, the Abyss That Dreams** — a planet-scale Kraken Leviathan with full canon, game design, and the pipelines to keep generating more.

### Canon (STAGING — does not touch the locked Ten)
- **Monster System taxonomy** (`.arcanea/lore/creatures/MONSTER_SYSTEM.md`): T0 Motes → T1 Beasts → T2 Shades (the existing psychological bestiary, slotted in) → **T3 Leviathans / Wild Godbeasts (NEW)** → T4 Gate Godbeasts (locked), with a Shadow corruption track at every tier.
- **The Leviathan tier** registered in `CANON_LOCKED.md` (STAGING ⏳) + approval-log entries. Leviathans are **unbonded** beasts of Nero's Unformed that roam **outside** the Ten Gates — the locked Ten Godbeasts are untouched.
- **Nethyssa** (`.arcanea/lore/leviathans/nethyssa.md`): Water + Void, the sub-Gate "Abyssal Hum", kin-adjacent to Veloura, kept dreaming by the **Tidesong**; material = the **Nethyss Pearl**; corruption = **the Drowned Shadow** (extinction-tier). Plus indexes + a game-design spec (raid/world-boss, Master+ gating, phase ladder, drops, weaknesses).

### Book
- `book/legends-of-arcanea/the-rising-of-nethyssa.md` — The First Drowning, as Arcanean flood-scripture.
- `book/bestiary-of-creation/the-kraken-brood.md` — Krakenlings, Abyssal Tendrils, Drowned Heralds.

### Code (MCP)
- `packages/arcanea-mcp/src/data/leviathans/` — `Leviathan` / `GameMonster` interfaces (extend `BestiaryCreature`) + Nethyssa + brood data.
- `generators.ts` + `index.ts` — new `generate_leviathan` MCP tool (returns canonical Nethyssa for named Water/Void, else a procedural Wild Godbeast).

### Tests ✅
- `packages/arcanea-mcp/tests/leviathan-generators.test.mjs` — **46 tests, 46 passing** (Node built-in test runner).
  - `generateLeviathan`: named+Water returns canonical Nethyssa fields exactly; named+unregistered element returns procedural with `note`; `named=false` always procedural, no `note`.
  - `classifyCanonFit`: 14 tests covering spectrum/tier/gate logic — leviathan scale → T3/gate required, godbeast → T4/gate required, bonded override, scale-wins-over-bonded, Nethyssa capture profile end-to-end.
  - `inferCaptureType`: 16 tests covering extension normalization, first-match semantics, mime fallback, unknown → undefined, defaultCanonTier priors.
- Logic for `classifyCanonFit` and `inferCaptureType` inlined in test file (`.arcanea/intake/` is tool-agnostic, not in the arcanea-mcp tsconfig build graph — same pattern as `feedback-bridge.test.mjs`).

### Pipelines & loops
- **Arcanea Hermes** intake→conversion: skill + agent + `/hermes` command + `.arcanea/intake/` substrate (classify capture → grade canon fit → fan to producers → canon-gate → review queue; never auto-publishes).
- **Generation**: `.arcanea/gen/` aesthetic lanes + multi-harness routing (Grok Imagine / Codex gpt-image-2 / Antigravity NB2) + a ready-to-paste Nethyssa prompt-pack.
- **Workflows**: `.arcanea/WORKFLOWS.md` — lore / asset / web3 loops, each wired to `canon-check` + `lock-decision` + the visual-creation council.

## Status / gates
- **Nethyssa is STAGING.** LOCKED canon requires Frank's explicit `/lock-decision`.
- Image generation runs in the external harnesses' own CLIs — this PR ships the prompt-packs + routing they consume.
- `arcanea-web` CI: ✅ Ready. `arcanea-2` (apps/academy): ❌ pre-existing failure unrelated to this branch (apps/academy missing `next` in package.json).

## Verification
- **46/46 unit tests passing** (`node --test packages/arcanea-mcp/tests/leviathan-generators.test.mjs`)
- New MCP TS (`generators.ts`, `leviathans/index.ts`, `index.ts` edits) parse clean. CI build on this PR is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rnGVLqNrCLJz2KJnEcRos)_