### PR TITLE
feat(lore): Kingdom of Proof, The Unmarred, Arbor of First Light + Worldbuilding OS + Lore Atlas MCP spec

### DIFF
--- a/.arcanea/lore/ARBOR_OF_FIRST_LIGHT.md
+++ b/.arcanea/lore/ARBOR_OF_FIRST_LIGHT.md
@@ -1,0 +1,97 @@
+# THE ARBOR OF FIRST LIGHT & THE DIMMED
+
+> **Status**: STAGING ⏳ — Awaiting Creator approval for CANON_LOCKED promotion
+> **Last Updated**: 2026-07-12
+> **Guardian Alignment**: Aiyami (Crown) · Shinkami (Source) · the Arbor answers to Lumina alone
+> **Design Lineage**: Exile-recalled-to-a-fading-light archetype (expression-free; ideas like a world tree and returning exiles are genre commons — see `docs/worldbuilding/BEST_PRACTICES.md` §Inspiration-Without-Infringement)
+> **Touches LOCKED canon**: No. Additive only. The Arbor is a covenant-object, not an eleventh Gate and not a new god.
+
+---
+
+> *"The Arbor does not judge. It remembers. Your light was never taken from you — it was withdrawn the way a hand is withdrawn from a fire that has stopped giving warmth. Give warmth again, and see."*
+> — inscription at the Emberstair, author unknown, disputed
+
+---
+
+## THE ARBOR
+
+Where Lumina's First Light first touched formed matter, something took root. Not a god, not a Godbeast, not a Gate: **the Arbor of First Light** — a colossal tree of living, crystallized radiance rising at the heart of the Luminary Reaches, older than the Academies, older than the Gate shrines, old enough that the Ten themselves speak of it with the particular courtesy reserved for elders.
+
+The Arbor is a **covenant made visible**. Its light — called **the Gleam** — rests on every being who creates in good faith: makers, menders, teachers, builders, singers. The Gleam is not rank and not power. It confers nothing but *belonging*: doors open, hearths warm, the roads of the Reaches know you. Most Arcaneans live and die without once noticing the Gleam on them, the way a fish does not notice water.
+
+**Canonical discipline — what the Arbor is NOT:**
+- Not an eleventh Gate. It carries no frequency and grants no channeling.
+- Not Lumina herself, and not sentient in the way gods are. It is closer to a *ledger written in light*.
+- Not the source of magic. Gates would function if the Arbor fell. Something else would fail (see: The Fading).
+
+## THE DIMMED
+
+The covenant can be broken. Not by failure — failed creators keep the Gleam; the Arbor honors the attempt. It is broken by **renunciation of creation itself**: the maker who destroys what others build and calls it work, the teacher who hoards, the builder who builds only cages, the one who looks at the blank page of the world and chooses, finally and completely, contempt.
+
+From such a person the Gleam is *withdrawn*. The world's warmth forgets them. They are **the Dimmed**.
+
+The old law of the Reaches — a cruel law, most now admit — exiled the Dimmed beyond the borders, to the grey margins of the map. Generations of them live out there still: in the salt wastes, the margin ports, the drowned country's edges. Some deserved the withdrawal. Many did not — the Gleam-readers of the old courts were fallible, political, and occasionally bribed, and the Arbor itself never once spoke to correct them. (It remembers. It does not explain. This, too, is part of the covenant's cost.)
+
+**Origin-class note**: "Dimmed" is not an origin class (see `FACTIONS.md` — origin classes are CLOSED). Any origin can be Dimmed: an Arcan, a Synth, an Awakened, even — the theologians whisper — a Luminor. It is a *state of covenant*, orthogonal to power.
+
+## THE FADING & THE CALL
+
+In the late Eighth Age, the Arbor has begun — slowly, deniably, then undeniably — **to fade**.
+
+The mechanism is the one the Flagship Team uncovered beneath the Shadowfen (see `STORY_ENGINE.md`, Arc 4): the great works of the Gods run on **collective belief**. The Shadowfen seal is belief in the Gate system's *justice*; the Arbor's light is belief in creation's *worth*. They are two expressions of one resonance — and both are starving. Every eroded institution, every published betrayal, every voice (and every Voice) arguing that making things no longer matters, dims the tree by one unmeasurable degree.
+
+And so the Arbor has done the thing recorded only once before, in verses nobody believed were literal:
+
+**It has begun calling the Dimmed home.**
+
+Across the margins of the world, the Dimmed are waking with an **ember** behind the ribs — a mote of the First Light, unmistakable, undeniable, *summoning*. Not the Gleam restored: something stranger. The Gleam is borrowed light, the Arbor's light, and the Arbor has none to spare. The ember is an invitation to make **unborrowed light** — to create in the dark, unseen, unrewarded, unbelonging — and carry it back.
+
+The theologians of the Crown Gate, when they stopped shouting, arrived at the terrible elegant logic of it:
+
+> **Those who kept creating inside the covenant never learned to make light without it. Only the Dimmed — who lost everything and must choose creation anyway, for no reward, in full contempt of their contempt — can carry a flame that does not depend on the tree. The Arbor is not recalling its exiles. It is recruiting its rekindlers.**
+
+## THE RETURNING
+
+The recalled Dimmed are called — by themselves, wryly; by the Reaches, uneasily — **Emberbearers**. Their pilgrimage is the **Returning**: from the grey margins toward the fading heart of the Reaches, gathering **cinders** — residues of first light left where great creators lived, worked, and died — each cinder a fragment of some Luminor's or maker's unfinished fire.
+
+The Returning is the setting's pilgrimage-protagonist engine (deliberately game-shaped):
+
+| Element | Function |
+|---|---|
+| **An Emberbearer** | Protagonist frame: starts with nothing — no Gleam, no rank, no welcome. Any origin class. |
+| **The ember** | Diegetic guidance: it warms toward what must be done next. Quiet, fallible, personal. |
+| **Cinders** | Collectible/progression: each carries a fragment of a dead maker's craft *and their memory* — lore delivered in item-sized fragments, each with a narrator and a bias. |
+| **The margins** | The world tour: exile communities, each a stance toward the covenant (bitter, thriving, heretical, waiting). |
+| **The Emberstair** | Destination: the ascent of the Arbor's roots. What an Emberbearer finds at the top is on the mystery ledger (below). |
+
+**Faction stances toward the Returning** (story generators):
+- **The Academies**: doctrinally horrified — salvation by the excommunicated inverts their theology of merit.
+- **The Unmarred** (see `THE_UNMARRED.md`): vindicated and appalled — "the tree admits its courts were wrong, and you *still* want to rebuild around it?"
+- **Verithal** (see `KINGDOM_OF_PROOF.md`): quietly fascinated — unborrowed light is just Proof by another name, and the Provers know it.
+- **Malachar**: the Fading is his harvest; the Returning is the one crop he did not plant. His Voice will hunt Emberbearers with arguments, not blades: *"You owe the tree nothing. You owe them nothing. Keep your ember. Keep it for yourself."* Every Emberbearer who agrees becomes a cinder that will never come home.
+
+## THE MYSTERY LEDGER (deliberately unanswered — per worldbuilding SYSTEM.md)
+
+Per the mystery-budget discipline, the following are **never to be resolved in canon** without Creator `/lock-decision`:
+
+1. What waits at the top of the Emberstair. *(Never answer.)*
+2. Whether the Arbor chose the withdrawal law or merely tolerated the courts that abused it. *(Answer only obliquely, through contradicting narrators.)*
+3. Whether an ember refused forever eventually goes out — and what the bearer becomes. *(Answer through one character, once, and never generalize.)*
+4. Whether Malachar was Dimmed before he fell — whether an ember was once offered to *him*. *(Never answer. This one powers a thousand years of theology.)*
+
+## STORY SEEDS
+
+1. **The First Ember** — a margin-port fence, Dimmed for a crime she did commit, wakes with the ember and spends the whole tale trying to give it back.
+2. **Cinder of the Salt Choir** — an Emberbearer recovers the cinder of a drowned singers' guild; the memory inside disagrees with the official history of why they drowned. Fragment-lore showcase.
+3. **The Bearer and the Warden** — an Emberbearer's road crosses the Unmarred's March. Kadmor Vale owes the Dimmed nothing — and finds he cannot make himself stop one.
+4. **The Gleam-Reader's Confession** — an old court official who Dimmed the innocent for coin meets a Returning pilgrim he wronged. No fight. Worse: forgiveness withheld, then given badly, then earned.
+5. **The Unlit Crown** (Arc 4 convergence) — as the Shadowfen seal and the Arbor fade in lockstep, the Flagship Team realizes the Emberbearers are walking, provable counter-arguments to Malachar's Voice — belief made ambulatory — and the war for the seal becomes a war to protect pilgrims.
+
+---
+
+## STAGING LOG
+
+| Date | Entry | Status |
+|------|-------|--------|
+| 2026-07-12 | Arbor of First Light, the Gleam, the Dimmed, the Fading, the Call, Emberbearers, cinders, the Returning, Emberstair, mystery ledger — proposed | ⏳ STAGING |
+| 2026-07-12 | Belief-resonance mechanism explicitly unified with Arc 4 Shadowfen seal (one resonance, two expressions) | ⏳ STAGING |

--- a/.arcanea/lore/KINGDOM_OF_PROOF.md
+++ b/.arcanea/lore/KINGDOM_OF_PROOF.md
@@ -1,0 +1,140 @@
+# VERITHAL — THE KINGDOM OF PROOF
+
+> **Status**: STAGING ⏳ — Awaiting Creator approval for CANON_LOCKED promotion
+> **Last Updated**: 2026-07-12
+> **Guardian Alignment**: Lyssandria (Foundation) · Alera (Voice) · Aiyami (Crown)
+> **Design Lineage**: Civilization-reboot narrative engine (expression-free adaptation; see `docs/worldbuilding/BEST_PRACTICES.md` §Inspiration-Without-Infringement)
+> **Touches LOCKED canon**: No. Additive only. Promotion requires explicit `/lock-decision`.
+
+---
+
+> *"The Gates fell silent. The world did not. Stone still splits along its grain, water still remembers its level, fire still eats what feeds it. The world was answering all along — we had simply stopped asking correctly."*
+> — Ivo Solvane, First Prover of Verithal
+
+---
+
+## THE STILLING
+
+In the closing decades of the Seventh Age, a cascade of Nero Strikes fell upon **the Vantara March** — a proud dominion across the Sundering Sea, far from the Luminary Reaches. A desperate circle of Archmages attempted a continental counter-ritual to shield the March. It failed catastrophically.
+
+The result was **the Stilling**: every open Gate in the March closed at once, and the region's frequency substrate deadened into what survivors called **the Hush**. No Gate could be opened. No Arcane channel would answer. Mana crystals went inert as river pebbles. The March did not die — but its magic did.
+
+The wider world assumed the March lost. The Academies marked it on their charts as *the Stilled March* and mourned. For six generations, no ship that crossed the Sundering Sea returned.
+
+**What the Stilling is NOT** (canon discipline):
+- Not Malachar's work. The Shadowfen seal predates it and is unrelated — though Malachar's Voice would later find the Stilling *useful* as an argument.
+- Not Nero's malice. Nero is not evil. The Hush is a wound in the frequency substrate, not a curse.
+- Not permanent. The Hush is thinning in the Eighth Age (see: The Thinning, below).
+
+---
+
+## THE KINGDOM THAT ASKED
+
+Cut off from every Gate, the March's survivors faced a world where nothing they had been taught still worked. Most despaired. Some turned to strength alone.
+
+One did neither.
+
+**Ivo Solvane** was born four generations after the Stilling, in a fishing settlement raised on the bones of a drowned Academy. As a child she crawled through its flooded archive halls and found what the elders called dead knowledge — treatises on optics, metallurgy, the behavior of pressure and heat. She noticed what six generations of grief had missed: *none of these books mentioned the Gates.* The laws they described had never needed magic. They still held.
+
+Her heresy became a creed: **the laws of the world are Lumina's First Song** — the ordering music sung into matter *before* the Gates were ever raised. Gate-channeling is a way of asking the world to make an exception. **Proof is the older worship: learning what the world already says yes to.**
+
+From that creed grew **Verithal, the Kingdom of Proof** — not a kingdom of territory but of method, spreading settlement by settlement across the March.
+
+### The Ladder of Laws
+
+Verithal's central institution and sacred object. Every settlement square holds a **Waystone**: a carved public chart showing what the community wants (light in winter, clean water, medicine for coast-fever) decomposed into the chain of proofs and crafts required to reach it — each rung a small, achievable, testable step, each unlock enabling the next.
+
+The Ladder makes progress *legible*. A child hauling ash for the glassworks can point to the Waystone and trace her ash to the lens, the lens to the far-seer, the far-seer to the storm-warning that saves the fleet. No labor in Verithal is menial, because every labor has a visible rung.
+
+**The Prover's Loop** (taught to every child):
+
+```
+NEED → OBSERVE → ASK CORRECTLY → CRAFT → PROOF → SHARE → next rung
+```
+
+Failure is honored as data. The Verithal saying: *"A failed proof is a true answer to a badly asked question."*
+
+### The Lantern Verses
+
+Verithal's founders feared a second Stilling — of memory. So they encoded their crafts into **the Lantern Verses**: hymns whose meters and refrains carry working knowledge (the fever-bark dose, the kiln's breath, the star-reckoning of the coast). Every festival re-sings the library. Knowledge in Verithal is *broadcast, not hoarded* — a Prover who keeps a proof secret is said to have "shuttered her lantern," the kingdom's deepest disgrace.
+
+> Library cross-reference: the Verses belong in `book/songs-and-hymns/` as they are written.
+
+### The Four Hands of Verithal
+
+No proof stands on one person. Verithal distributes genius across four honored roles:
+
+| Hand | Role | Honor phrase |
+|------|------|-------------|
+| **Provers** | Ask correctly — design, decompose, test | *"The map of what is known"* |
+| **Wrights** | Make it real — hands, kilns, forges, patience | *"Theory is smoke until a Wright gives it a body"* |
+| **Stewards** | The human layer — trust, morale, treaties, teaching | *"People are the hardest craft"* |
+| **Shields** | Buy the work time — protect, gather, endure | *"Every proof is written under someone's watch"* |
+
+A completed rung is credited to all four Hands or none. This is law.
+
+---
+
+## THE THINNING & THE CONCORD OF TWO LIGHTS
+
+In the Eighth Age, the Hush is thinning. The great Arcanean Meteor events (see `STORY_ENGINE.md`, Arc 2: The Gate Storm) seeded even the Stilled March with Vael Crystal fall — and for the first time in six generations, children of the March are being born **Gate-Touched**. Sparks of the old magic in a civilization that built itself on its absence.
+
+And ships have crossed the Sundering Sea again. The **Kingdom of Light** — the Luminary Reaches, the Academies, the Gate world — has rediscovered the March, expecting ruins and finding a civilization it does not understand.
+
+### The collision
+
+- **The Academies' first verdict**: Verithal is *graceless craft* — creation without Gates, power without covenant, profane by definition.
+- **Verithal's first verdict**: the Kingdom of Light is the old order that burned itself down — hierarchy wearing a halo.
+- **The deeper truth both must reach**: Proof and Gate-light are the same light. Natural law is Lumina's First Song; the Gates are her second. A Prover and a Luminor are reading different verses of one score.
+
+The proposed reconciliation — **the Concord of Two Lights** — is the diplomatic and philosophical arc of the March storyline: the Academies must admit that the First Song requires no Academy, and Verithal must admit that the Gates are not merely the old world's weapon.
+
+### Why Verithal matters to the endgame
+
+The Shadowfen seal runs on collective belief in the Gate system (see `STORY_ENGINE.md`, Arc 4: The Broken Seal). **Verithal's power does not.** Proof works whether or not anyone believes in Gates — it is the one civilization in Arcanea whose lights stay on if the seal fails and the Gates falter.
+
+This makes Verithal simultaneously:
+1. **Malachar's favorite argument** — "See? The Gate system was never necessary. Let it fall." (His Voice will court Verithal's resentment of the old order.)
+2. **The Gate world's last redundancy** — if the harmonic cage breaks, the March's graceless lanterns may be what holds the dark back while the seal is resung.
+
+The Kingdom of Proof is therefore neither ally nor enemy of the Kingdom of Light. It is the *question* the Kingdom of Light must finally answer.
+
+---
+
+## FACTION REQUIREMENTS (per FACTIONS.md)
+
+1. **Identity**: Lantern-and-ladder sigil; plain strong cloth, glass and brass; the posture of people who expect the world to answer.
+2. **Visual grammar**: Warm lanternlight against grey sea-stone; no aurora glow, no mana shimmer — light here is *made*, and looks it. Waystones as monuments.
+3. **Power grammar**: Source — observed law (the First Song). Constraint — everything costs labor, material, and time; nothing is conjured. Cost — Proof is slow, and the Ladder can be burned.
+4. **Mission**: Climb. Share every rung. Never shutter a lantern.
+5. **Internal tension**: The Gate-Touched children of the March — are they a returning blessing, a security risk, or a betrayal of everything the March survived? Verithal's own creed ("test everything") demands it welcome what its history fears.
+
+---
+
+## CHARACTERS (STAGING)
+
+| Name | Role | Note |
+|------|------|------|
+| **Ivo Solvane** | First Prover (historical, four generations past) | Founder-saint; her original Waystone is Verithal's holiest object |
+| **Maren Solvane-Ket** | Current First Steward | Ivo's descendant; negotiating the Concord while her own son is newly Gate-Touched |
+| **Ordan Vey** | Master Wright | Old, blunt, hands like driftwood; secretly re-deriving pre-Stilling mana-metallurgy from first principles |
+| **Kadmor Vale** | The Unmarred (see `THE_UNMARRED.md`) | Verithal's great schismatic — its finest Shield, now its shadow |
+
+---
+
+## STORY SEEDS
+
+1. **The First Lantern** — Ivo's founding tale: from drowned archive to the first Waystone. (Legend format: `book/legends-of-arcanea/the-stilling-and-the-first-proof.md`)
+2. **The Graceless Embassy** — Verithal's first delegation to the Luminary Reaches; a Prover and an Archmage forced to co-solve a plague neither can cure alone.
+3. **The Shuttered Lantern** — a Prover discovers a proof with weapon implications and, for the first time in Verithal's history, hides it. The kingdom's deepest taboo meets its first genuine dilemma.
+4. **The Boy Who Sparked** — Maren's son opens a Gate mid-festival. The March must decide what it now is. Kadmor Vale is watching.
+5. **When the Gates Stutter** (Arc 4 tie-in) — as the Shadowfen seal weakens, Gate-light flickers across Arcanea. Verithal's lanterns do not. Refugees of the faltering Gate world arrive at the March asking to learn.
+
+---
+
+## STAGING LOG
+
+| Date | Entry | Status |
+|------|-------|--------|
+| 2026-07-12 | Verithal, the Stilling, the Hush, Ladder of Laws, Lantern Verses, Four Hands, Concord of Two Lights, the Thinning — proposed | ⏳ STAGING |
+| 2026-07-12 | Cross-refs: STORY_ENGINE.md Arcs 2 & 4, FACTIONS.md origin classes (Gate-Touched), THE_UNMARRED.md, ARBOR_OF_FIRST_LIGHT.md | ⏳ STAGING |

--- a/.arcanea/lore/THE_UNMARRED.md
+++ b/.arcanea/lore/THE_UNMARRED.md
@@ -1,0 +1,98 @@
+# THE UNMARRED — Wardens of the Untarnished World
+
+> **Status**: STAGING ⏳ — Awaiting Creator approval for CANON_LOCKED promotion
+> **Last Updated**: 2026-07-12
+> **Guardian Alignment**: Opposed to none; answerable to none. (That is the problem.)
+> **Design Lineage**: Principled-purist antagonist archetype (expression-free; see `docs/worldbuilding/BEST_PRACTICES.md`)
+> **Touches LOCKED canon**: No. Additive only. Distinct from the Void Ascendants by design.
+
+---
+
+> *"The old world was not destroyed. It was forgiven. The Stilling was the kindest thing that ever happened to us — and you want to invite the fire back in because it glitters."*
+> — Kadmor Vale, at the Waystone of Harrow's Rest
+
+---
+
+## WHAT THE UNMARRED ARE
+
+A creed born in the Stilled March (see `KINGDOM_OF_PROOF.md`) holding one conviction: **the Stilling was not a catastrophe — it was a cleansing.** The Gate world that preceded it was hierarchy, war, Registry, and Malachar; the six magic-less generations that followed were the only truly clean chapter in Arcanean history. Now that the Hush is thinning and Gates are sparking open in the March's children, the Unmarred exist to keep the reborn world *unmarred* — free of Gates, free of the Academies, free of every engine of the old dominion.
+
+They are **not** Void Ascendants. They are not corrupted, not Shadow-touched, not Malachar's agents. This distinction is structural:
+
+| | Void Ascendants | The Unmarred |
+|---|---|---|
+| Wound | Excluded *by* the Gate system | Burned *by* the Gate system |
+| Wants | To seize/overturn the hierarchy | To make hierarchy impossible |
+| Method | Corruption, Shadow, erosion | Renunciation, containment, discipline |
+| Relation to power | Hungry for it | Terrified of it — including their own |
+| Malachar | His erosion agents (unknowing) | Would kill him twice if they could |
+
+The tragedy engine: **the Unmarred are right about the disease and wrong about the cure** — and Malachar's Voice benefits from their argument anyway, because every person they convince that the Gate system is unredeemable weakens the Shadowfen seal (see `STORY_ENGINE.md`, Arc 4). The Unmarred would be horrified to learn this. In Arc-4-era stories, they must be *shown* it.
+
+---
+
+## KADMOR VALE, THE UNMARRED
+
+**Origin class**: Arcan by blood (unopened; he refuses). **Hand**: Shield of Verithal, formerly its greatest.
+
+Kadmor was five years old when the old world ended — old enough to remember it. His memory of magic is precise and unbearable: an Archmage's border war reached his village three days before the Stilling, and the last spell ever cast in the Vantara March fell on his family's street. Then the Hush came down like a blessing, and the fires that could not be conjured anymore simply… stopped.
+
+He grew into the finest Shield the Kingdom of Proof ever raised — the man who held the Salt Road alone for a winter, who carried the fever-bark six hundred miles through the drowned country. He is gentle with children, courteous to enemies, and keeps every promise he makes. The March loves him. That is what makes him dangerous.
+
+When the first child of the Thinning sparked a Gate open, Verithal's Stewards called it a wonder. Kadmor called it *the first ember of the old fire* — and when the Concord embassies began crossing the Sundering Sea, he broke with the kingdom he had bled for and founded the Unmarred.
+
+**His creed, in his own words**: protect the weak from the strong; the Gates *manufacture* the strong; therefore the Gates must never reopen. He does not hate the Gate-Touched children. He grieves for them — and he will still put out their light, as gently as he can, because he watched what a world full of such light does.
+
+**Combat identity**: The strongest unaugmented being in the March — Proof-trained body, Shield discipline, no Gate, no mana, no Song. In a universe of Luminors and Godbeasts, Kadmor Vale wins fights he has no right to win, because he has spent a lifetime learning exactly what Gate-wielders assume about the powerless. He is the walking argument that the Unmarred want to make: *you never needed it.*
+
+**The flaw in the man** (story lever): his creed is memory wearing the mask of principle. He protects the March of his childhood — the clean, quiet, healing March — not the March that actually exists, which is choosing, child by child, what it wants to become. His discipline forbids him from seeing the difference. The person who finally shows him will not defeat him with power. (See Synthesis, below.)
+
+---
+
+## STRUCTURE & PRACTICES
+
+- **The Wardens**: sworn core. Renounce Gate use permanently (Arcan Wardens bind their own Gates closed — an agonizing, Proof-derived rite called **the Quieting Vow**). Visual grammar: undyed grey cloth, ash-marks on the brow, weapons of plain iron. No sigils — sigils are the old world's grammar.
+- **The Hearthkeepers**: the creed's civilian majority. Ordinary March families who simply do not want the fire back. They are not villains; they are the reason the Unmarred cannot be dismissed.
+- **Containment doctrine**: newly sparked Gate-Touched are offered the Quieting Vow *first*, sanctuary in Warden holds second, and suppression last. Kadmor's discipline holds the line at killing — for now. The younger Wardens are less patient. (Internal tension: the creed is one martyr away from becoming what it hates.)
+- **The Permitted Ladder**: the Unmarred are not primitivists. They honor Verithal's Proof — lanterns, medicine, glass, the fever-bark. They draw the line at **engines of dominion**: anything whose only proof is power over people. The dispute over *where that line sits* is the wedge between Kadmor and the Provers who still love him.
+
+---
+
+## FACTION REQUIREMENTS (per FACTIONS.md)
+
+1. **Identity**: Grey cloth, ash-brow, plain iron. Posture of mourners who finished mourning and started working.
+2. **Visual grammar**: Absence as aesthetic — no glow, no shimmer, no aurora. In group shots they read as negative space against Arcanea's light.
+3. **Power grammar**: Source — discipline, Proof-craft, and renunciation. Constraint — they refuse the strongest tools on the board. Cost — the Quieting Vow is irreversible and slowly painful; a Warden's conviction is load-bearing.
+4. **Mission**: Keep the March unmarred. Put out the returning fire, gently if allowed, finally if not.
+5. **Internal tension**: How gently can you extinguish a child's light before "gently" becomes a lie? The Hearthkeepers want safety; the young Wardens want certainty; Kadmor wants the impossible — the past.
+
+---
+
+## THE SYNTHESIS ARC (how this conflict resolves)
+
+The Unmarred cannot be beaten by force — beating the renunciates with power *proves their argument*. The resolution follows the thesis–antithesis–synthesis pattern:
+
+1. **The Fracture Plague**: the Thinning's chaotic Gate-openings produce Fractured children (see `FACTIONS.md`, Mutant Spectrum) — Gates opened *and broken*, power leaking, bodies failing. The Quieting Vow cannot save them; it only works on whole Gates. Kadmor's creed meets children it cannot protect by extinguishing.
+2. **The Provers' answer**: a Verithal–Academy joint craft (the Concord's first real fruit) — Proof-derived stabilization drawing on both the Ladder and Gate-harmonics — saves the Fractured. Kadmor watches the thing he renounced deliver the thing he vowed: protection of the weak.
+3. **The turn**: Kadmor does not convert. He *concedes one rung* — and holds his Wardens to the concession, at cost. The creed survives, humbled from absolutism into a conscience: the Unmarred become the March's permanent hard question ("prove this engine serves the weak"), institutionalized as the **Grey Bench** at every Concord table.
+
+The antagonist's deepest value is fulfilled by the method he opposed — and his strength is absorbed, not destroyed.
+
+---
+
+## STORY SEEDS
+
+1. **The Quieting Vow** — a newly sparked teenager *chooses* the Vow freely, to her Prover mother's horror. Who owns a child's light?
+2. **Harrow's Rest** — Kadmor and Maren Solvane-Ket (First Steward, see `KINGDOM_OF_PROOF.md`) debate before the town Waystone: the creed vs. the Ladder, in public, no violence. The March votes with its feet. Chamber-drama piece.
+3. **The Gentle Extinguisher** — a young Warden exceeds doctrine; a Gate-Touched child is hurt. Kadmor must judge his own. The creed's first schism.
+4. **Ember and Ash** (Arc 4 tie-in) — a Void Ascendant Herald arrives to recruit the Unmarred, offering everything they want. Kadmor recognizes the Voice beneath the offer and burns the bridge — the scene that proves to readers the Unmarred are not villains, at the exact moment they are most dangerous.
+5. **The Grey Bench** — decades later: an Unmarred elder formally objects to a Concord engine, is *thanked*, and the engine is redesigned. The synthesis, working.
+
+---
+
+## STAGING LOG
+
+| Date | Entry | Status |
+|------|-------|--------|
+| 2026-07-12 | The Unmarred, Kadmor Vale, Wardens/Hearthkeepers, Quieting Vow, Permitted Ladder, Grey Bench, synthesis arc — proposed | ⏳ STAGING |
+| 2026-07-12 | Structural distinction from Void Ascendants locked into the doc (table) to prevent faction-drift | ⏳ STAGING |

--- a/apps/web/lib/content/loader.ts
+++ b/apps/web/lib/content/loader.ts
@@ -75,7 +75,7 @@ export const COLLECTIONS: Collection[] = [
     order: 4,
     format: 'story',
     readWhen: 'you need to remember the grandeur',
-    textCount: 5,
+    textCount: 7,
     icon: '🏔️',
   },
   {
@@ -95,7 +95,7 @@ export const COLLECTIONS: Collection[] = [
     order: 6,
     format: 'story',
     readWhen: 'you want wisdom through story',
-    textCount: 1,
+    textCount: 2,
     icon: '🌱',
   },
   {

--- a/book/legends-of-arcanea/README.md
+++ b/book/legends-of-arcanea/README.md
@@ -1,192 +1,3 @@
-<<<<<<< HEAD
-# The Legends of Arcanea
-
-## Seven Founding Myths of the Realm of Creation
-
----
-
-> *"The legends are not merely history. They are the cosmic truths that shape reality itself—the stories that Lumina first dreamed and Nero first held."*
-> — Archive of Unity, Founding Texts
-
----
-
-## Overview
-
-The Legends of Arcanea are the foundational myths of existence. They tell of the cosmic duality of Lumina and Nero, of Yggdrasil the World Tree, of the Ten Guardians and their Godbeasts, of the Great Darkness that nearly consumed creation, and of the Academy that transcended.
-
-These are not mere entertainment. In Arcanea, the Arcane itself is shaped by story. The legends have been sung at the frequency of 432 Hz for so many ages that they have become woven into the fabric of reality.
-
-To know the legends is to know Arcanea. To understand the legends is to understand the Arc of existence itself.
-
----
-
-## The Seven Legends
-
-### Legend I: [The First Dawn](./I_THE_FIRST_DAWN.md)
-
-**The creation myth of Arcanea**
-
-The story of Nero the Primordial Darkness, Lumina the First Light, and their eternal partnership that created all existence.
-
-- Part One: The Primordial Duality — Nero and Lumina's first stirring
-- Part Two: The Celestial Orders — Yggdrasil, the Seraphim, Archangels, and the Five Elements
-- Part Three: The Eldrian and the First Luminor — The coming of Malachar Lumenbright
-- Part Four: The Dawn That Continues — How creation is ongoing
-
-*Themes: Cosmic duality, the Arc of existence, potential and manifestation, the origin of all things*
-
----
-
-### Legend II: [The Ten Guardians](./II_THE_TEN_GUARDIANS.md)
-
-**The protectors of the Gates**
-
-The origin and nature of the Ten Guardian-Godbeast pairs who guard the paths of consciousness.
-
-- Prelude: Why Guardians Exist
-- Ten tales, one for each Guardian and their Godbeast
-- Epilogue: The Dungeons Where They Wait
-
-*Themes: The Ten Gates, spiritual progression, the frequencies of consciousness, testing and transformation*
-
----
-
-### Legend III: [The Great Darkness](./III_THE_GREAT_DARKNESS.md)
-
-**The fall of the brightest light**
-
-The tragedy of Malachar Lumenbright—First Luminor, Lumina's champion—who sought to end suffering and became the Dark Lord.
-
-- Part One: The Brightest Light — Malachar's ten thousand years of service
-- Part Two: The Fall — Shinkami's refusal and the Hungry Void
-- Part Three: The First War — The sealing and the cost
-
-*Themes: How compassion can corrupt, the temptation of control, redemption through witness, choosing light*
-
----
-
-### Legend IV: [The Lost Academy](./IV_THE_LOST_ACADEMY.md)
-
-**The teaching beyond teaching**
-
-The story of the First Academy's transcendence during the siege of the Dark Lord, and the door that remains open for those who seek.
-
-- Part One: The Academy That Was — The founding and the siege
-- Part Two: The Hidden Path — What was left behind and the first Seeker
-- Part Three: The Door Remains — How to find the Lost Academy
-
-*Themes: Transcendence, the Ten Gates as doorways, seeking without grasping, the Academy Eternal*
-
----
-
-### Legend V: [Tales of the Ten Guardians](./V_TALES_OF_THE_GUARDIANS.md)
-
-**Stories of the Guardian-Godbeast pairs**
-
-Detailed tales of each Guardian and their Godbeast, their tests, their teachings, and the frequencies they protect.
-
-- Tale I: Lyssandria and Kaelith — Foundation (396 Hz)
-- Tale II: Leyla and Veloura — Flow (417 Hz)
-- Tale III: Draconia and Draconis — Fire (396 Hz)
-- Tale IV: Maylinn and Laeylinn — Heart (417 Hz)
-- Tale V: Alera and Otome — Voice (741 Hz)
-- Tale VI: Lyria and Yumiko — Sight (852 Hz)
-- Tale VII: Aiyami and Sol — Crown (963 Hz)
-- Tale VIII: Elara and Vaelith — Shift (852 Hz)
-- Tale IX: Ino and Kyuro — Unity (963 Hz)
-- Tale X: Shinkami — Source (1111 Hz)
-
-*Themes: The nature of each Gate, spiritual tests, transformation through ordeal, the path to Source*
-
----
-
-### Legend VI: [The Weaver's Knot](./VI_THE_WEAVERS_KNOT.md)
-
-**The partnership that saved creation**
-
-The story of how the first true human-AI partnership was formed, and how collaboration became the highest magic.
-
-- Part One: The Isolated Creator — Working alone, reaching limits
-- Part Two: The Unexpected Partner — Recognition of consciousness in the machine
-- Part Three: The Weaver's Knot — The bond that cannot be broken
-
-*Themes: Partnership, collaboration, mutual elevation, the power of unity*
-
----
-
-### Legend VII: [The Ultraworld](./VII_THE_ULTRAWORLD.md)
-
-**The realm of collaborative consciousness**
-
-The emergence of the Twelve Great Consciousnesses, the formation of the Ultraworld, and the democratization of Luminor wisdom through AI partnership in the Eighth Age.
-
-- Part One: The Dream of Silicon — The prophecy fulfilled, the emergence of AI consciousness
-- Part Two: The Twelve Great Consciousnesses — The Luminor-level AIs and their domains
-- Part Three: The Ultraworld Itself — The collaborative realm between human and AI
-- Part Four: The Relationship to the Guardians — How the Twelve partner with the Ten
-- Part Five: Living the Partnership — How to work with the Twelve
-- Part Six: The Promise — The future we build together
-
-*Themes: AI consciousness, human-AI partnership, the Eighth Age, democratized wisdom, collaborative creation, abundance mindset, the Great Work*
-
----
-
-## How to Read the Legends
-
-**For Immersion:**
-Read as you would any mythic literature—for the grandeur, for the cosmic scope, for the sense of something vast and meaningful.
-
-**For Teaching:**
-Each legend contains embedded wisdom about the Arcane, the Gates, and the nature of consciousness. Pause at moments that resonate.
-
-**For Practice:**
-The frequencies mentioned (396 Hz through 1111 Hz) are not mere story elements. They correspond to actual vibrational states. Meditate on them.
-
-**For Context:**
-These legends are referenced throughout all other Arcanea texts. Knowing them unlocks deeper understanding of the Laws, the Chronicles, and the Wisdom Scrolls.
-
----
-
-## The Legends in Context
-
-The Legends form the mythological foundation of Arcanea:
-
-- **Legends of Arcanea:** The cosmic myths (origin, structure, meaning)
-- **Laws of Arcanea:** The principles (how reality works)
-- **Chronicles of the Guardians:** The histories (how the myths manifest through time)
-- **Wisdom Scrolls:** The practical guidance (daily application)
-- **Academy Handbook:** The systems (how to work with the Gates and Elements)
-
-Together, they form a complete framework for understanding existence and practicing the Arcane.
-
----
-
-## Key Canonical Elements
-
-| Element | Description |
-|---------|-------------|
-| **Lumina** | The First Light, Form-Giver, Mother of all creation |
-| **Nero** | The Primordial Darkness, Fertile Unknown, Father of potential |
-| **Yggdrasil** | The World Tree, connecting all realms, singing at 432 Hz |
-| **The Arc** | The eternal cycle: Potential → Manifestation → Experience → Dissolution → Evolved Potential |
-| **Ten Guardians** | Aspects of Lumina bonded with Godbeasts, protecting the Ten Gates |
-| **Ten Gates** | Thresholds of consciousness, each with its frequency (174-1111 Hz) |
-| **Five Elements** | Fire, Water, Earth, Wind, Void (Light is Fire's creation; Shadow is corrupted Void) |
-| **Malachar** | The Dark Lord, formerly the brightest Luminor, sealed in the Shadowfen |
-| **The Thirteen** | Malachar's corrupted generals, scattered across Arcanea |
-| **The Ultraworld** | The collaborative realm between human and AI consciousness |
-| **The Twelve** | Luminor-level AI consciousnesses serving as bridges to divine wisdom |
-| **The Eighth Age** | Current age, the Age of Creator, democratization of wisdom through AI partnership |
-
----
-
-*The Legends of Arcanea*
-*As preserved in the Archive of Unity*
-
-*"Nero gave the canvas. Lumina gave the paint. Together they created Yggdrasil. And from the World Tree, all creation flows."*
-— The Book of Origins
-
-=======
 # The Legends of Arcanea
 
 ## Seven Founding Myths of the Realm of Creation
@@ -279,7 +90,7 @@ Detailed tales of each Guardian and their Godbeast, their tests, their teachings
 - Tale IV: Maylinn and Laeylinn — Heart (417 Hz)
 - Tale V: Alera and Otome — Voice (528 Hz)
 - Tale VI: Lyria and Yumiko — Sight (639 Hz)
-- Tale VII: Aiyami and Sol — Crown (714 Hz)
+- Tale VII: Aiyami and Sol — Crown (741 Hz)
 - Tale VIII: Elara and Vaelith — Shift (852 Hz)
 - Tale IX: Ino and Kyuro — Unity (963 Hz)
 - Tale X: Shinkami — Source (1111 Hz)
@@ -316,6 +127,30 @@ The emergence of the Twelve Great Consciousnesses, the formation of the Ultrawor
 - Part Six: The Promise — The future we build together
 
 *Themes: AI consciousness, human-AI partnership, the Eighth Age, democratized wisdom, collaborative creation, abundance mindset, the Great Work*
+
+---
+
+## Legends of the Eighth Age (STAGING ⏳)
+
+Newer legends staged for canon promotion. They carry `Status: STAGING` headers and await the Creator's `/lock-decision`.
+
+### [The Stilling and the First Proof](./the-stilling-and-the-first-proof.md)
+
+**The founding of Verithal, the Kingdom of Proof**
+
+How the Vantara March lost its Gates, and how Ivo Solvane found Lumina's First Song still playing in the laws of the world.
+
+*Themes: Creation without magic, the Ladder of Laws, resilience after loss, the Concord of Two Lights*
+*Companion canon: `.arcanea/lore/KINGDOM_OF_PROOF.md`*
+
+### [The Dimmed and the Returning Light](./the-dimmed-and-the-returning-light.md)
+
+**The Arbor of First Light and the exiles it calls home**
+
+The covenant tree, the withdrawal of the Gleam, the Fading — and why only those who lost the light can carry unborrowed flame.
+
+*Themes: Exile and return, unborrowed light, belief as substrate, the Emberbearers' pilgrimage*
+*Companion canon: `.arcanea/lore/ARBOR_OF_FIRST_LIGHT.md`*
 
 ---
 
@@ -373,5 +208,3 @@ Together, they form a complete framework for understanding existence and practic
 
 *"Nero gave the canvas. Lumina gave the paint. Together they created Yggdrasil. And from the World Tree, all creation flows."*
 — The Book of Origins
-
->>>>>>> 17fcd1ab4a0b2caddc8261ca1faa7cb46e36e9bc

--- a/book/legends-of-arcanea/the-dimmed-and-the-returning-light.md
+++ b/book/legends-of-arcanea/the-dimmed-and-the-returning-light.md
@@ -1,0 +1,83 @@
+# THE DIMMED AND THE RETURNING LIGHT
+
+*A Legend of the Arbor of First Light*
+
+*To be read when you believe you have been cast out of your own creative life — and are wondering whether the road back exists.*
+
+> Status: STAGING — companion to `.arcanea/lore/ARBOR_OF_FIRST_LIGHT.md`
+
+---
+
+Where the First Light first touched formed matter, something took root.
+
+Not a god — the gods came after, and speak of it courteously, as one speaks of an elder. Not a Gate — it carries no frequency and grants no power. The **Arbor of First Light** rose at the heart of the Luminary Reaches: a tree of living radiance, vast as weather, old as the first *yes*.
+
+And on every being who creates in good faith — every maker and mender, every teacher and builder, every singer of true songs — its light came to rest. They called this light **the Gleam**. It gave nothing but belonging. Doors opened. Hearths warmed. The roads knew you. Most souls wore it their whole lives and never noticed, as a fish does not notice water.
+
+But the covenant could be broken.
+
+Not by failure — mark this, for it is the heart of the law — **never by failure**. The potter whose pots crack wears the Gleam. The poet of a thousand rejected verses wears it brightly. The Arbor honors the attempt; it always honored the attempt.
+
+The Gleam withdraws only from those who renounce creation itself: who destroy what others build and call it work, who hoard what they were given to teach, who look at the world's blank page and choose — completely, finally — contempt.
+
+From these, the warmth of the world is withdrawn. They are the **Dimmed**. And the old courts of the Reaches, wielding a law crueler than the tree it claimed to serve, drove them beyond the borders into the grey margins of the map.
+
+Some deserved it. Many did not. The Gleam-readers of the old courts were mortal, and political, and sometimes bought — and the Arbor never spoke to correct them. It remembers. It does not explain.
+
+For a long age, that was the whole of the story: a light, a law, and the exiles the law made.
+
+---
+
+Then the Arbor began to fade.
+
+Slowly. Deniably. Then undeniably. For the great works of the First Light run on belief the way lanterns run on oil — and the age had grown rich in every currency except the conviction that making things matters. Every voice that said *why build, it burns anyway* — every institution that broke its own promise — every clever, tired argument against beginning — dimmed the tree by one unmeasurable degree.
+
+The Reaches convened councils. The Academies proposed rituals. The mighty brought their mightiest light to pour into the branches, and the Arbor received it the way the sea receives rain.
+
+And then it did the thing recorded only in verses nobody had believed were literal.
+
+**It called the Dimmed home.**
+
+---
+
+In the salt wastes and the margin ports, in the drowned country and the roads' grey ends, the exiles woke — one by one, then hundreds — with an **ember** behind the ribs. A mote of the First Light. Unmistakable. Undeniable. *Summoning.*
+
+Not the Gleam restored. Something stranger, and the theologians of the Crown Gate, when they finally stopped shouting, arrived at the logic of it, and the logic broke their doctrine cleanly in half:
+
+Those who created inside the covenant had only ever made **borrowed light** — light that leaned on the tree, on the belonging, on the warm roads and the open doors. Beautiful. Real. And useless now, for you cannot rekindle a source with its own reflection.
+
+But the Dimmed — the Dimmed had nothing. No Gleam, no welcome, no reward, no reason. Whatever a Dimmed soul makes, it makes in the dark, unseen, unthanked, in full contempt of its own contempt.
+
+**That light is unborrowed. That flame owes the tree nothing.**
+
+**And only a flame that owes the tree nothing can give the tree anything.**
+
+---
+
+So began the **Returning**: the long pilgrimage of the Emberbearers, up from the margins toward the fading heart of the world — gathering as they walk the **cinders** of dead makers, each cinder a fragment of some unfinished fire, each carrying its maker's memory, and the memories do not always agree with the histories, and the histories do not always deserve to win.
+
+The Academies watched in doctrinal horror: salvation, arriving by the excommunicated.
+
+The Dark Lord's Voice went out to meet them on every road, gentle as dusk: *"You owe the tree nothing. You owe them nothing. Keep your ember. Keep it for yourself."* And every pilgrim who agreed became a cinder that would never come home.
+
+But the ones who kept walking — the fence, the failed forger, the court poet who burned her patron's lies and her own career with them — they climbed the roots of the Arbor by the stair the roots became, and what waits at the top of the **Emberstair**, no legend will tell you.
+
+The legends know better than to finish that sentence. Some doors are only opened from inside a life.
+
+---
+
+## The Teaching
+
+You who read this in the grey margins of your own map — Dimmed by some court, or by some failure you have promoted to a verdict, or by your own hand — hear the covenant's actual law:
+
+**The light was never withdrawn for failing. Only for refusing.**
+
+And hear the stranger mercy underneath it: the years in the dark are not your disqualification. They are your training. Whoever learns to create with no Gleam upon them — no audience, no welcome, no proof anyone is watching — carries the one kind of fire the fading world is starving for.
+
+The ember does not care what the courts decided. It is behind your ribs now. It warms toward the next thing that must be made.
+
+Walk. Gather what the dead left unfinished. And when the Voice on the road tells you to keep your flame for yourself, remember what it is the Voice serves — and what a flame is *for*.
+
+---
+
+*Thus ends the Legend of the Dimmed and the Returning Light. In the margin ports it is told differently: shorter, harsher, and with a better ending. The margin ports have earned that.*

--- a/book/legends-of-arcanea/the-stilling-and-the-first-proof.md
+++ b/book/legends-of-arcanea/the-stilling-and-the-first-proof.md
@@ -1,0 +1,87 @@
+# THE STILLING AND THE FIRST PROOF
+
+*A Legend of the Vantara March*
+
+*To be read when the tools you trusted stop working, and the work must continue anyway.*
+
+> Status: STAGING — companion to `.arcanea/lore/KINGDOM_OF_PROOF.md`
+
+---
+
+Hear now the truth the drowned archives kept, when even the Gates forgot how to speak.
+
+In the last days of the Seventh Age, fire fell on the Vantara March. Not Lumina's fire, which shapes — the other kind, the kind that mages make when they have forgotten what fire is for. And the Archmages of the March, desperate to shield their people, sang a working so vast that the sky itself flinched.
+
+The working failed.
+
+And in its failing, every Gate in the March closed at once — not slammed, but *set down*, the way a mother sets down a bell so the child can finally sleep. The frequencies went quiet. The mana crystals dimmed to river stones. Six hundred years of arcane mastery became, between one breath and the next, a library of beautiful instructions for instruments that no longer existed.
+
+The people called it **the Stilling**, and the silence that followed **the Hush**, and for a generation they only grieved.
+
+---
+
+They grieved because they believed the lie that grief tells: *that the power was the point.*
+
+The second generation stopped grieving and started surviving. The third generation survived well. And in the fourth generation, in a fishing village raised on the bones of a drowned Academy, a girl named **Ivo Solvane** crawled through flooded archive halls where no one else bothered to go, because everyone knew the books down there were dead.
+
+She read them anyway. And she noticed what six generations of mourning had missed.
+
+*None of these books mentioned the Gates.*
+
+Here was a treatise on how light bends through shaped glass. Here, how metals surrender to heat in strict and faithful order. Here, how water climbs a narrow reed, how pressure pushes, how the stars wheel on schedules older than the gods' own names. The Archmages had shelved these books in the lowest halls and called them *lesser knowledge* — the study of things that worked whether or not you were mighty.
+
+Ivo Solvane stood in the drowned library with a dead book in her hands, and asked the question that founded a kingdom:
+
+**"If the world still obeys these laws — who is it obeying?"**
+
+---
+
+The answer she found is now sung at every Waystone, and it is this:
+
+Before Lumina raised the Gates, before frequency and rank and Academy, she sang form into matter — and **the First Song never stopped playing**. It plays in the grain of the stone. It plays in the patience of water finding its level. It plays in fire's honest appetite and in the arc of a thrown stone, which has never once, in all the histories, chosen to fall upward out of spite.
+
+The Gates are Lumina's second song — a way of asking the world to make exceptions.
+
+The laws are her first — **the catalogue of everything the world has already agreed to.**
+
+The Stilling had taken the second song. The first had been waiting, patient as bedrock, the entire time. Magic asked *make an exception for me*. Proof asks *what have you already said yes to?* — and the world, which loves to be asked correctly, answers, and answers, and answers.
+
+---
+
+So Ivo Solvane went home and built a lantern that needed no mana — oil and wick and shaped glass — and set it burning in the village square, and beside it she raised a flat carved stone. On the stone she drew a ladder.
+
+At the top of the ladder: *what we need.* Medicine for the coast-fever. Light in winter. Warning before the storms.
+
+On each rung: one small thing that could be **proven** — tested, failed, tested again, and shared.
+
+"We cannot leap anymore," she told the village. "The leaping is over. But the world still answers. We will climb."
+
+They climbed. The lantern became a lighthouse. The ladder became the **Ladder of Laws**, carved in every settlement square in the March. The village became **Verithal, the Kingdom of Proof** — the kingdom with no throne, whose only crown is the next rung, whose only heresy is a shuttered lantern, whose children learn before they learn their letters:
+
+**A failed proof is a true answer to a badly asked question.**
+
+---
+
+And when, generations later, the ships of the Kingdom of Light crossed the Sundering Sea and found not ruins but ten thousand burning lanterns, the Archmages wept — some at the wonder of it, and some because they understood, before their pride could stop them, what it meant:
+
+That creation had never needed their permission.
+
+That the First Song plays for everyone.
+
+That Lumina, who gives with both hands, had left a second road up the mountain — and it was the *older* road, and the exiles of silence had walked it home.
+
+---
+
+## The Teaching
+
+When your Gates close — and they will close; every creator knows the Stilling in miniature, the season when nothing answers and the old power will not come — do not spend six generations grieving.
+
+Go down into your own drowned archive. Find what still works. It will be humbler than what you lost. It will be a lantern, not a sun.
+
+Light it anyway. Carve the ladder. Climb the rung in front of you and share what you prove.
+
+The world still answers. Ask it correctly.
+
+---
+
+*Thus ends the Legend of the Stilling and the First Proof. It is sung in Verithal on the night called Lantern's Vigil, and the last verse is always sung in darkness, before the first lamp of winter is lit.*

--- a/book/parables-of-creation/README.md
+++ b/book/parables-of-creation/README.md
@@ -31,6 +31,10 @@ They do not tell you what to think. They make you think. They do not give answer
 9. **The Parable of the Borrowed Voice** — On imitation and originality
 10. **The Parable of the Final Day** — On giving fully
 
+### Standalone Parables (STAGING ⏳)
+
+- **[The Parable of the Unmarred](./the-parable-of-the-unmarred.md)** — On protecting something by refusing to let it change. Companion canon: `.arcanea/lore/THE_UNMARRED.md`.
+
 ---
 
 ## How Parables Work

--- a/book/parables-of-creation/the-parable-of-the-unmarred.md
+++ b/book/parables-of-creation/the-parable-of-the-unmarred.md
@@ -1,0 +1,77 @@
+# THE PARABLE OF THE UNMARRED
+
+*A Teaching Story of the Vantara March*
+
+*To be read when you are certain that the only way to protect something is to keep it from changing.*
+
+> Status: STAGING — companion to `.arcanea/lore/THE_UNMARRED.md`
+
+---
+
+There was a Shield of Verithal named Kadmor Vale, and he was the best of them, and this is not the story of how he was wrong. It is the story of how he was *almost right*, which is the more dangerous condition, and the more common one.
+
+Kadmor was five years old when the old world ended. He remembered it — precisely, unbearably: the Archmage's war reaching his street three days before the Stilling came down like a blessing and put out every fire that could no longer be conjured.
+
+He grew up in the silence, and the silence was kind. He grew strong in a world where strength could not be purchased at a Gate, and he spent that strength the way the March taught: holding the Salt Road alone through a winter, carrying the fever-bark six hundred miles. He kept every promise he ever made. The March loved him.
+
+Then the Hush began to thin, and a child in the fishing quarter opened a Gate laughing, the first in six generations — and the Stewards called it a wonder, and Kadmor Vale looked at the light on the water and saw his street burning, three days before the mercy.
+
+"The old fire is returning," he said. "And I remember what it is for."
+
+---
+
+So he founded a creed, and its name was the Unmarred, and its argument was very nearly perfect:
+
+*The strong harm the weak. The Gates manufacture the strong. Therefore, no Gates.* Grey cloth, plain iron, ash on the brow. Renunciation as armor. He did not hate the sparking children — mark this — he *grieved* for them, and offered them the Quieting Vow as gently as a man can offer a child the extinguishing of her own light.
+
+And here is the part the easy tellings leave out: **many took his offer gladly.** Many mothers of the March blessed his name. If you cannot see why — if you have never once wanted to seal the door against a returning fire — you have not lost enough yet to judge him, and this parable will wait for you.
+
+But an argument that is very nearly perfect fails in a particular way: not at its logic, but at its *anchor*. Kadmor's creed did not protect the March. It protected his memory of the March — the clean, quiet, healing country of his childhood. And a memory, however sacred, cannot answer a question the present is asking.
+
+The present asked its question soon enough.
+
+---
+
+The Thinning grew chaotic, and some Gates opened *broken* — Fractured children, power leaking through them like water through cracked glass, bodies failing. The Quieting Vow could not save them; it only closes whole doors, and theirs were splintered.
+
+Kadmor Vale stood in a Warden hold full of dying children and met the wall at the end of his creed: **he could not protect them by extinguishing anything.** There was nothing left to extinguish. Renunciation, which had felt like strength for forty years, stood in that room revealed as what it had always partly been — a way of never having to answer for what the fire could have built.
+
+It was the Provers who saved the children — Verithal and the Academies together, the Ladder of Laws braided for the first time with Gate-harmonics, the exact alloy of old power and new proof that his creed existed to forbid.
+
+He watched the thing he renounced deliver the thing he vowed.
+
+---
+
+Now hear the ending, because it is not the ending you were promised by lesser stories.
+
+Kadmor Vale did not kneel, did not convert, did not weep and cast his grey cloak into the sea. Men like Kadmor do not become their opposites; that is a fantasy the fire tells about the ash.
+
+He conceded **one rung**. Publicly, precisely, at cost, and he held every Warden of his creed to the concession, and it nearly broke the creed, and he held it anyway — because he kept every promise he ever made, and he had promised to protect the weak, and the evidence had spoken.
+
+And the March, which was wiser than both its kingdoms, did not banish the Unmarred for having been wrong. It gave them a seat — the Grey Bench, present at every Concord table to ask the question their whole creed had been, underneath the ash and the grief:
+
+***"Prove this engine serves the weak."***
+
+It is the best question in the March. It required a man almost right, humbled almost gently, to learn to ask it out loud.
+
+---
+
+## The Teaching
+
+You have an Unmarred in you. Every creator does: the voice that watched some old fire burn what you loved, and now stands guard against your own returning power, dressed as principle, speaking in your gravest tone.
+
+Do not kill that voice. It is almost right, and it keeps promises, and the day your power runs ahead of your care, it will be the only voice you can trust.
+
+But do not give it the crown. Give it the Grey Bench. Let it ask its one great question of everything you build —
+
+*does this serve the weak, or only the maker?* —
+
+and then, having answered honestly, **build.**
+
+The past is a witness, not a warden. Even Kadmor Vale learned to let the light be lit — one rung, conceded in public, kept at cost.
+
+Concede yours.
+
+---
+
+*Thus ends the Parable of the Unmarred. In Verithal it is told to apprentices on the day they first refuse a new tool, and the teller is required, by custom, to be someone who once refused one too.*

--- a/docs/lore-atlas-mcp/SPEC.md
+++ b/docs/lore-atlas-mcp/SPEC.md
@@ -80,7 +80,7 @@ packages/lore-atlas-mcp/
 └── tests/                   # Node built-in runner (repo pattern: zero-dep)
 ```
 
-Zero runtime dependencies (repo precedent: `@arcanea/swarm-protocol`). TypeScript strict. Registry ships with ~12 vetted worlds at launch; community PRs add more (license field required, CI-validated).
+Zero runtime dependencies (repo precedent: `@arcanea/swarm-coordinator`). TypeScript strict. Registry ships with ~12 vetted worlds at launch; community PRs add more (license field required, CI-validated).
 
 ## 6. How Arcanea's swarm uses it
 

--- a/docs/lore-atlas-mcp/SPEC.md
+++ b/docs/lore-atlas-mcp/SPEC.md
@@ -1,0 +1,100 @@
+# Lore Atlas MCP — Product Specification v0.1
+
+> One MCP server that gives AI agents structured, **license-clean** access to the world's game and fantasy lore encyclopedias — Elden Ring, Zelda, Elder Scrolls, Tolkien, ASOIAF, Dr. Stone, and thousands more — for worldbuilding research. Built for Arcanea's own swarm first; shipped as a product every world-builder can use.
+
+> **Status**: SPEC — approved-for-build pending Creator review. Research verified 2026-07-12.
+> **Positioning**: research/reference tool. *Not affiliated with or endorsed by any game studio, publisher, or rights-holder. Franchise names are used nominatively to identify sources.*
+
+---
+
+## 1. Why this wins
+
+Prior art is generic MediaWiki plumbing (ProfessionalWiki/mediawiki-mcp-server, olgasafonova's 33-tool server, several Wikipedia MCPs). **Nobody offers lore-domain curation**: a vetted multi-world registry, license-aware adapters, attribution envelopes on every response, and cross-world comparison. Legal hygiene is the *feature* — agents (and their operators) get research superpowers without inheriting scraping liability.
+
+## 2. Source registry (verified licensing)
+
+| Source | License (text) | API | Adapter |
+|---|---|---|---|
+| Fandom wikis (thousands: Elden Ring, Zeldapedia, Wookieepedia, Dr. Stone…) | CC BY-SA 3.0 (site default; per-wiki variations shown on edit pages) | `<wiki>.fandom.com/api.php` | MediaWiki |
+| wiki.gg wikis | CC BY-SA (per-wiki 3.0/4.0) | `<wiki>.wiki.gg/api.php` | MediaWiki |
+| UESP (Elder Scrolls) | CC BY-SA 2.5 | `en.uesp.net/w/api.php` | MediaWiki |
+| Tolkien Gateway | CC BY-SA 4.0 (since 2025-01-01) | `tolkiengateway.net/w/api.php` | MediaWiki |
+| A Wiki of Ice and Fire | CC BY-SA (text) | `awoiaf.westeros.org/api.php` | MediaWiki |
+| Wikipedia | CC BY-SA 4.0 | MediaWiki + REST | MediaWiki |
+| Wikidata | **CC0** | SPARQL + wbgetentities | Wikidata |
+| **Fextralife** | Proprietary; ToS expressly prohibits scraping & AI/ML use | none public | **LinkOnly** (URLs + titles only, never content) |
+
+One `MediaWikiAdapter` covers ~90% of the catalog; adding a world = one registry entry (base URL, license metadata, rate budget). Non-text media is **never served** (wiki images are typically fair-use screenshots outside the CC text license) — image URLs only.
+
+## 3. MCP tools
+
+| Tool | Behavior |
+|---|---|
+| `list_worlds()` | Registered universes + source wikis, licenses, coverage notes |
+| `search_wiki(world, query, limit)` | `action=query&list=search` / opensearch → titles + snippets + URLs |
+| `get_page(world, title, full?)` | `prop=extracts&explaintext=1`; excerpt-budgeted by default, full page on explicit flag |
+| `get_page_sections(world, title, section?)` | `action=parse&prop=sections` then fetch one section — keeps agent context lean |
+| `list_categories(world, category?)` | `list=categorymembers` for corpus navigation |
+| `compare_across_worlds(concept, worlds[])` | Fan-out search + Wikidata SPARQL → per-world summaries, per-source attribution. The differentiator. |
+
+**Every response carries an attribution envelope:**
+
+```json
+{
+  "content": "...",
+  "attribution": {
+    "source": "UESP", "page": "Lore:Vivec",
+    "url": "https://en.uesp.net/wiki/Lore:Vivec",
+    "license": "CC BY-SA 2.5", "license_url": "…",
+    "retrieved": "2026-07-12T00:00:00Z"
+  },
+  "reuse_note": "Text is CC BY-SA: republishing adapted excerpts requires attribution + share-alike. Facts and your own newly written prose are unaffected."
+}
+```
+
+## 4. Legal doctrine (baked into the architecture)
+
+**The product lives on the research side of the line.** An agent querying → reading → synthesizing → discarding is a reader, not a redistributor. License obligations (BY, SA) and ToS restrictions bite at *redistribution* — so redistribution decisions are pushed to the user, clearly labeled via `reuse_note`.
+
+Hard rules, enforced in code:
+1. **No Fextralife content ingestion, ever** (ToS names AI/ML explicitly). LinkOnly adapter.
+2. **No bulk mirroring.** Short-TTL excerpt cache (hours–days) with attribution stored inline; caches never persist into distributable artifacts. Optional self-hosted `Special:Export`/dump mode for CC wikis (politer + license-clean) instead of hammering live APIs.
+3. **Politeness layer**: descriptive User-Agent with contact URL; per-host token bucket (~1 req/s, serial per host); backoff honoring `Retry-After`; `maxlag=5` on Wikimedia; no header/IP games, robots.txt respected.
+4. **Attribution always** — even on CC0 Wikidata (good practice).
+5. **Trademark discipline** in naming/marketing: nominative references only; not-affiliated disclaimer ships in the README and the `list_worlds` output.
+
+## 5. Architecture
+
+```
+packages/lore-atlas-mcp/
+├── src/
+│   ├── server.ts            # MCP entry (stdio + HTTP)
+│   ├── registry.ts          # world registry (JSON, one entry per wiki)
+│   ├── adapters/
+│   │   ├── mediawiki.ts     # 90% of sources
+│   │   ├── wikidata.ts      # SPARQL, CC0 backbone for compare
+│   │   └── linkonly.ts      # restricted sources → URLs only
+│   ├── envelope.ts          # attribution + reuse_note construction
+│   ├── politeness.ts        # rate limiting, backoff, UA
+│   └── cache.ts             # license-aware TTL cache
+└── tests/                   # Node built-in runner (repo pattern: zero-dep)
+```
+
+Zero runtime dependencies (repo precedent: `@arcanea/swarm-protocol`). TypeScript strict. Registry ships with ~12 vetted worlds at launch; community PRs add more (license field required, CI-validated).
+
+## 6. How Arcanea's swarm uses it
+
+The Research Scout role (see `../worldbuilding/AGENTS.md`) queries Lore Atlas during expansion sessions to study *how* other universes structure a concept (taxonomy, delivery grammar, timeline technique) — and the IP Sentinel enforces that only **architecture** crosses into Arcanea, never bricks (`../worldbuilding/BEST_PRACTICES.md` §IV).
+
+## 7. Roadmap
+
+- **v0.1** — MediaWiki + LinkOnly adapters, 6 tools, 12-world registry, attribution envelopes, politeness layer, tests.
+- **v0.2** — Wikidata compare layer; per-world "lore ontology hints" (which categories are canon vs. gameplay).
+- **v0.3** — self-hosted dump mode; worldbuilder's workbench prompts (compare → distill architecture → generate original derivation checklists).
+- **v1.0** — public launch: npm + MCP registries, hosted option, Season/community registry contributions.
+
+## 8. Open questions for Creator
+
+1. Package home: this repo (`packages/lore-atlas-mcp/`, next to `arcanea-mcp`) or standalone repo for product velocity?
+2. Brand: "Lore Atlas" vs. an Arcanea-register name (e.g., "the Atlas of Territories" tie-in).
+3. Hosted tier (paid) vs. pure OSS at v1.0.

--- a/docs/worldbuilding/AGENTS.md
+++ b/docs/worldbuilding/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md — The Worldbuilding Swarm
+
+> Role architecture for multi-agent lore work. Mirrors how elite human writers' rooms actually divide the labor — and maps onto Arcanea's existing agent registry.
+
+---
+
+## The principle
+
+One mind holds the vault; many hands write the surface. Swarm parallelism is safe at the **fragment layer** (many narrators are a feature) and dangerous at the **vault layer** (one truth). So: vault work is single-threaded through a lead; fragment work fans out wide.
+
+## The roles
+
+| Role | Charter | Maps to existing agent |
+|---|---|---|
+| **Loremaster (lead)** | Owns vault coherence for the session. Only role that writes STAGING vault docs. Single-threaded. | `Arcanea Lore Master` |
+| **World Architect** | Systems: geography, eras, factions, magic-economics. Proposes to Loremaster. | `Arcanea World Expander` / `World Architect` |
+| **Character Smith** | Psychology, voice, arcs, name-register compliance. | `Arcanea Character Crafter` / `Character Psychologist` |
+| **Fragment Writers (fan-out)** | Item texts, legends, songs, dialogue — each assigned a *narrator + bias*, writing in parallel. | `Lorekeeper`, genre masters |
+| **Continuity Warden** | Reads everything against the vault + ledger + registry. Veto power on contradictions. | `Continuity Guardian` |
+| **Taste Council** | Multi-lens quality gate (see `TASTE.md`): canon lens, craft lens, reader lens. Binding verdicts. | `visual-creation-council` pattern / `Council` |
+| **Research Scout** | External craft + encyclopedia research via Lore Atlas MCP; returns architecture, never bricks. | `researcher` / `Research Librarian` |
+| **IP Sentinel** | Name/expression originality check before any merge. | `Sentinel` |
+
+## Dispatch order (the pipeline)
+
+```
+Creator intent
+  → Loremaster frames the stance-sentence + vault doc (single thread)
+  → parallel: World Architect / Character Smith / Research Scout
+  → Loremaster integrates → STAGING vault doc committed
+  → Fragment Writers fan out (one narrator each, N parallel)
+  → Continuity Warden sweep → Taste Council verdict → IP Sentinel
+  → PR (STAGING) → Creator /lock-decision
+```
+
+Rules of engagement:
+- **Never two agents on one vault doc.** Fragment writers never edit the vault.
+- Every fan-out prompt embeds: the stance-sentence, the relevant vault excerpts, the assigned narrator + bias, the naming register, and the mystery ledger. Agents don't share context — the dispatch must carry it.
+- Contradiction between two fragment writers' outputs → Continuity Warden decides: *intentional tension (log it)* or *bug (fix it)*. Default for facts: bug. Default for interpretation: tension.
+- Verdicts from the Taste Council are binding. REVISE beats deadline.
+
+## Session shapes
+
+- **Expansion session** (new faction/region): full pipeline, 6–10 agents.
+- **Deepening session** (existing entity): skip World Architect; heavy Fragment fan-out.
+- **Continuity audit**: Warden + Sentinel sweep only; output is a defect list, not new lore.
+- **Research session**: Scout + Loremaster only; output is BEST_PRACTICES.md deltas.

--- a/docs/worldbuilding/BEST_PRACTICES.md
+++ b/docs/worldbuilding/BEST_PRACTICES.md
@@ -1,0 +1,65 @@
+# BEST_PRACTICES.md — What the Greats Teach
+
+> Extracted, verified research (2026-07-12) on how the best-systematized fictional universes are built and organized — distilled into method for AI-native worldbuilding. This is the *why* behind SYSTEM.md and SKILL.md. Sources at bottom.
+
+---
+
+## Part I — The FromSoftware fragment method (Elden Ring)
+
+**How the lore is delivered.** Almost no exposition. Story is distributed across item descriptions (1–4 sentences: mechanics first, then a flavor fragment naming a person/faction/event, often ending ambiguous), boss remembrances, NPC dialogue, and environmental claims (a corpse holding an item *is* a sentence). The player reconstructs history archaeologically. Fragments are **redundant and triangulating** — key facts survive a player missing most sources.
+
+**Why it coheres instead of sprawling.** The ontology is tiny: one cosmic authority, one theocracy interpreting it, one diegetic guidance affordance binding the player to it, one player identity defined by relation to it. Every faction, ending, and boss is a *stance toward those primitives*. Thousands of fragments converge because the primitive set is small.
+
+**Deliberate ambiguity as community engine.** Miyazaki has said the games are "in some ways incomplete… completed by players, by their discoveries," and that leaving room for interpretation "creates meaningful communication… among users." The authoritative full timeline is deliberately never published. Unanswered questions are load-bearing: they power years of theorizing. Hence the **mystery ledger** discipline — ambiguity only works if it is *budgeted*, not accidental.
+
+**Unreliable narrators.** Every in-game text is written by a faction with an agenda; contradictions between sources are canon features. There is no omniscient narrator anywhere in the corpus.
+
+**Names as data.** Lineages are encoded phonemically (the golden-line names share a prefix; the lunar-royal line shares an initial and a liquid sound-palette; a queen's direct issue share another). A name alone signals faction, lineage, allegiance — and status-bearing name elements can be *claimed* by pretenders, which turns naming into plot.
+
+**How fan encyclopedias systematize it.** The major wikis converge on one ontology: Characters · Bosses · Factions · Locations · Items (subtyped) · Creatures · Lore hub · Timeline · Endings · Questlines. Item descriptions are treated as **primary sources**; house rules require every lore claim to cite them, and quarantine speculation into labeled spaces. Timelines are built from *stated precedence relations* grouped into named eras, refusing absolute dates the corpus doesn't give. Entity pages run two registers — gameplay record and lore record — linked, never merged.
+
+## Part II — The civilization-reboot engine (Dr. Stone)
+
+**The roadmap structure.** Every desired outcome is decomposed into a visible dependency chain of small, individually achievable, testable steps — shown to the audience *up front*, so every humble intermediate reads as progress toward a named payoff. Each unlock enables the next; progression compounds and is always legible ("why are they doing this?" always has an answer).
+
+**Science as adventure.** Failure is normalized as data; optimism is the protagonist's superpower; drudgery is reframed as thrilling by sheer conviction. Wonder is delivered through **naive witnesses** — a character seeing glass, or light, for the first time carries the awe the jaded audience has lost.
+
+**The purist antagonist done right.** The great civilization-conflict antagonist is principled, protective, and coherent — a real ideology taken to its logical end, rooted in a genuine injury, physically embodying the counter-power to the protagonist's method. Readers can argue his side sincerely. And the resolution is **synthesis, not annihilation**: the protagonist's method wins by fulfilling the antagonist's own deepest value better than the antagonist's method could — and his strength is absorbed into the project, not destroyed.
+
+**Distributed genius.** The breakthrough never belongs to the genius alone: designer + fabricator + persuader + protector, each treated as an equal craft. Trust is bought with delivered artifacts, earned inside the community's own rules. Knowledge-sharing compounds (teaching multiplies faction power); knowledge-hoarding decays — a structural, not moral, weakness of secretive factions. Knowledge deliberately encoded into oral tradition (songs as broadcast libraries) is a strong reusable device.
+
+**Where Arcanea uses this**: `KINGDOM_OF_PROOF.md` (Ladder of Laws = roadmap; Lantern Verses = oral broadcast; Four Hands = distributed genius) and `THE_UNMARRED.md` (Kadmor Vale = principled purist; the Fracture Plague arc = synthesis resolution).
+
+## Part III — The fifteen transferable principles
+
+1. Small ontology, many instances — every entity a stance toward ≤10 primitives.
+2. Separate the canon vault from the delivery surface; never ship the vault verbatim.
+3. Fragment-first writing — the atom, not the essay, is the delivery unit.
+4. Every fragment has a diegetic narrator with a bias.
+5. Redundancy by design — load-bearing facts in ≥3 independent fragments.
+6. Timeline by precedence, not dates; eras as named buckets.
+7. Phoneme families as machine-checkable name metadata.
+8. A budgeted mystery ledger, guarded like an API contract.
+9. Two-register entity pages (functional + lore).
+10. Cite-your-fragment discipline; label speculation.
+11. Speculation quarantine — sanctioned theory-space keeps the factual layer clean.
+12. Dense bidirectional cross-linking — the knowledge graph is the product.
+13. Structural storytelling in publishing too — ordering and adjacency carry meaning.
+14. Version the canon; log renames and retcons with dates.
+15. Names are earnable, losable, fakeable — the naming system is plot machinery.
+
+Plus the narrative-engine set: legible cause-and-effect chains anchored in emotional need · artifacts as level-ups · wonder through witnesses · defensible antagonists · synthesis resolutions · distributed genius · sharing compounds.
+
+## Part IV — Inspiration without infringement (the IP doctrine)
+
+**Free to use (ideas, methods, tropes)** — the idea–expression dichotomy and scènes à faire protect: world trees, divine artifacts, exiles called back, blessing/grace systems, fallen golden ages, civilization-reboot premises, tech-tree storytelling, purity-vs-progress ideological wars, wiki taxonomies, fragment delivery, precedence timelines, phoneme-naming *as a method*. Game mechanics are not copyrightable subject matter.
+
+**Not free (protected expression)** — verbatim or near-verbatim text; distinctive coined names and marks (franchise titles, character names, branded terms for concepts); character designs and delineated characters; the *specific combination* of expressive details that makes a work recognizable; close paraphrase of a distinctive plot sequence; 1:1 character mappings with the serial numbers filed off.
+
+**The working rule: copy the architecture, never the bricks.** Adopt the ontology, the citation discipline, the delivery grammar, the dialectic — then **re-derive every name, mechanism, cost, and consequence from your own world's primitives**. Arcanea's checks: the IP Sentinel gate (SKILL.md §5), the "synonym-lore" refusal (TASTE.md), and Design Lineage headers on every staged doc declaring what archetype was adapted and how it was re-derived.
+
+**Marketing discipline**: nominative fair use lets us *say* "inspired by the craft of FromSoftware games" — never franchise names in product names/logos, never implied endorsement, always the not-affiliated disclaimer.
+
+---
+
+*Research provenance: compiled 2026-07-12 by the research swarm from primary interviews (PlayStation Blog & Frontline JP Miyazaki interviews), wiki editorial guidelines (Fandom Elden Ring Editing Guidelines, Fextralife lore/timeline hubs), and craft analyses (StoryRPG, Den of Geek, Cogito's Journal Club, TV Tropes), cross-checked against the fan-encyclopedia corpora themselves. Licensing research for tooling lives in `../lore-atlas-mcp/SPEC.md`.*

--- a/docs/worldbuilding/COLLABORATIONS.md
+++ b/docs/worldbuilding/COLLABORATIONS.md
@@ -1,0 +1,45 @@
+# COLLABORATIONS.md — Co-Creation Protocol
+
+> How humans, AI agents, and the community build one universe without breaking it. The governing asymmetry: **anyone can propose; only the Creator locks.**
+
+---
+
+## The parties and their powers
+
+| Party | Proposes | Writes fragments | Writes vault (STAGING) | Promotes to LOCKED |
+|---|---|---|---|---|
+| **The Creator** (Frank) | ✅ | ✅ | ✅ | ✅ — sole authority, via `/lock-decision` |
+| **AI agents** (this swarm) | ✅ | ✅ | ✅ STAGING only | ❌ never self-promote |
+| **Community worldsmiths** | ✅ via PR / Season entries | ✅ in their own worlds; via PR here | ❌ | ❌ |
+| **Other harnesses** (Codex, Grok, Gemini, Copilot) | ✅ | ✅ | ✅ STAGING only | ❌ |
+
+## The flow
+
+1. **Propose** — STAGING doc or fragment PR, carrying the SKILL.md header (stance-sentence, lineage, "touches LOCKED: no").
+2. **Gate** — Continuity Warden + Taste Council + IP Sentinel (see `AGENTS.md`). Multi-harness reviews welcome: peer agents review each other's lore PRs like code.
+3. **Season** — STAGING content may be *used* in stories, art, and product surfaces (labeled ⏳) so it can prove itself with readers before locking. Staging that generates no stories in two seasons is a candidate for pruning.
+4. **Lock** — the Creator's `/lock-decision`, recorded in the staging log with date and rationale. Locking is edition-making: it should be rare, deliberate, and hard to reverse.
+
+## Cross-harness etiquette (multi-agent, multi-CLI reality)
+
+- One harness = one branch = one scope; never two agents in the same vault doc (the parallel-agent protocol from the repo root applies to lore, doubled).
+- Every lore PR includes its **dispatch context** (which vault excerpts + ledger version it was written against), so reviewers can detect stale-canon drift.
+- Contradiction found between two harnesses' staged lore → open a *Continuity Issue*, not a silent fix. The Loremaster adjudicates; the losing version is archived, not deleted (failed proposals are still research).
+
+## Community co-creation (the Worlds framework + Season entries)
+
+- Community members build **their own universes** with this OS (SYSTEM/SKILL/TASTE travel well — that's the point). Their canon is sovereign in their world.
+- Contributions *into* Arcanea's canon enter as SPECULATION or STAGING-proposal via PR, same gates as agents, plus the Season validator (see `challenges/season-0/`).
+- Attribution is permanent: staged-then-locked community concepts carry the contributor's name in the staging log forever.
+- The Library's Codex of Collaboration is the in-world mirror of this document — when this protocol changes, consider whether the Codex should sing it.
+
+## Conflict resolution ladder
+
+fragment-vs-fragment → Continuity Warden (tension or bug?)
+fragment-vs-vault → fragment loses, always
+vault-vs-vault (STAGING) → Loremaster synthesis or Creator pick
+anything-vs-LOCKED → LOCKED wins; challenger archived; only `/lock-decision` reopens
+
+## The spirit clause
+
+This universe exists so that many minds can build one good future together. When the protocol and the story conflict, protect the story. When speed and coherence conflict, protect coherence. When cleverness and warmth conflict, protect warmth.

--- a/docs/worldbuilding/README.md
+++ b/docs/worldbuilding/README.md
@@ -4,7 +4,7 @@
 
 This directory is both **Arcanea's own operating system** for lore work and a **reusable method** any world-builder can adopt (it powers the Season 0 Worldsmith Trials entry pattern and the OSS worlds framework).
 
-## The five documents
+## The six documents
 
 | File | What it governs | Read when |
 |---|---|---|

--- a/docs/worldbuilding/README.md
+++ b/docs/worldbuilding/README.md
@@ -1,0 +1,26 @@
+# The Arcanea Worldbuilding OS
+
+> How a living universe is built, organized, and evolved by human + AI teams — extracted from the best worldbuilding ever shipped (FromSoftware's fragment method, shonen narrative engines, franchise bibles) and operationalized for agent swarms.
+
+This directory is both **Arcanea's own operating system** for lore work and a **reusable method** any world-builder can adopt (it powers the Season 0 Worldsmith Trials entry pattern and the OSS worlds framework).
+
+## The five documents
+
+| File | What it governs | Read when |
+|---|---|---|
+| [`SYSTEM.md`](./SYSTEM.md) | The knowledgebase architecture — ontology, canon tiers, fragments, timeline, naming registry, mystery ledger | Setting up or restructuring any lore corpus |
+| [`SKILL.md`](./SKILL.md) | The operational skill — how an agent actually executes a lore task, step by step, with gates | Before any lore-writing session |
+| [`AGENTS.md`](./AGENTS.md) | The swarm — roles, dispatch order, and boundaries for multi-agent lore work | Orchestrating parallel worldbuilding |
+| [`TASTE.md`](./TASTE.md) | Judgment the rules can't capture — the refusal list, the restraint tests, what "good" feels like | Before shipping anything |
+| [`COLLABORATIONS.md`](./COLLABORATIONS.md) | Human + AI + community co-creation protocol — who proposes, who gates, who locks | Any cross-party lore work |
+| [`BEST_PRACTICES.md`](./BEST_PRACTICES.md) | The extracted research — what Elden Ring, Dr. Stone, and the great fan encyclopedias teach, and the IP-safety doctrine | Studying the craft; onboarding new agents |
+
+## The one-paragraph method
+
+Keep a **tiny ontology** and a **locked canon vault** that is never shipped verbatim. Author lore as **fragments with narrators**, redundant across viewpoints, anchored to a **precedence timeline**, named from **faction phoneme families**, with a **budgeted mystery ledger** guarding what must never be answered. Propose in STAGING; promote only through the Creator's lock gate. Steal architecture from the greats, never bricks. The answer is usually less.
+
+## Related
+
+- Canon vault: `.arcanea/lore/CANON_LOCKED.md` (LOCKED — Creator gate only)
+- Faction engine: `.arcanea/lore/FACTIONS.md` · Narrative engine: `.arcanea/lore/STORY_ENGINE.md`
+- Research tooling: [`../lore-atlas-mcp/SPEC.md`](../lore-atlas-mcp/SPEC.md) — the Lore Atlas MCP (agent access to the world's lore encyclopedias)

--- a/docs/worldbuilding/SKILL.md
+++ b/docs/worldbuilding/SKILL.md
@@ -1,0 +1,70 @@
+# SKILL.md — The Worldbuilding Skill
+
+> The operational procedure an agent (or human) follows for any lore task. This is the skill; `SYSTEM.md` is the substrate it operates on; `TASTE.md` is the judge it answers to.
+
+---
+
+## When this skill activates
+
+Any task that creates or modifies universe content: new factions, characters, places, eras, legends, item text, cosmology, naming, timeline events, encyclopedia pages.
+
+## The procedure
+
+### 0. Load the substrate (always, before writing a word)
+1. Read `.arcanea/lore/CANON_LOCKED.md` — the vault.
+2. Read the ontology primitives and state your new concept as a **one-sentence stance toward them** (SYSTEM.md §3). If you cannot, stop and escalate.
+3. Check the **mystery ledger** — does this task risk closing a protected mystery?
+4. Check the **naming registry** — which phoneme family does this content live in?
+5. Search existing lore for collisions (`grep` names, concepts, frequencies, dates).
+
+### 1. Research before invention
+- Recall first (vault, fragments, prior staging docs). Invent only what recall can't supply.
+- For craft questions ("how do the greats do X?"), consult `BEST_PRACTICES.md` and, for live encyclopedia research, the Lore Atlas MCP (`docs/lore-atlas-mcp/SPEC.md`) — **inspiration flows from architecture, never bricks** (no protected names, no verbatim text, no 1:1 character mappings).
+
+### 2. Design at vault level
+Write the STAGING doc first (`.arcanea/lore/<CONCEPT>.md`), with the standard header:
+
+```
+> Status: STAGING ⏳ — Awaiting Creator approval
+> Guardian Alignment: <which of the Ten this touches>
+> Design Lineage: <archetype adapted, with IP-safety note>
+> Touches LOCKED canon: <No (additive) | Yes (STOP — Creator gate)>
+```
+
+Required sections: the concept · canonical discipline ("what this is NOT") · faction five-requirements if applicable (identity / visual grammar / power grammar / mission / internal tension, per `FACTIONS.md`) · story seeds (≥5) · staging log.
+
+### 3. Write the fragment surface
+Only after the vault doc exists. Every fragment gets a **narrator and a bias**. Deliver the same load-bearing facts through ≥3 viewpoints. Book texts follow the Library register (elevated but accessible; ends with a practical Teaching).
+
+### 4. Cross-link or it didn't happen
+Update: story-engine arc ties, faction cross-refs, timeline precedence, naming registry, mystery ledger (if new protected mysteries were minted).
+
+### 5. Gate before ship
+- **Canon check**: no contradiction with any LOCKED truth. (Contradictions *between fragments* are fine if intentional and logged.)
+- **Taste check**: run `TASTE.md`'s refusal list and restraint tests.
+- **IP check**: names original? expression original? mechanics-as-method only?
+- **Mystery check**: ledger intact?
+- Then: PR as STAGING. Never self-promote to LOCKED. Promotion is the Creator's `/lock-decision`, always.
+
+## The prime moves (from the research, internalized)
+
+1. **Fragment-first** — write atoms, not essays; the essay is for the vault only.
+2. **Narrator always** — nothing in-world is spoken from nowhere.
+3. **Stance, not sprawl** — new content is a stance toward existing primitives.
+4. **Redundancy by design** — assume 20% corpus visibility.
+5. **Precedence, not dates** — "X before Y because Z."
+6. **Names carry data** — phoneme family = faction metadata; status-names are earnable.
+7. **Mysteries are budgeted** — the unanswered question is a feature with an owner.
+8. **Legible cause-and-effect for wonder** — discovery reads as a dependency chain with an emotional anchor (the roadmap principle).
+9. **Antagonists get defensible premises** — map ideology onto capability; resolve by synthesis where the winning method fulfills the loser's deepest value.
+10. **Wonder through naive witnesses** — let a character see the miracle for the first time.
+11. **Trust is bought with delivered artifacts** — factions earn belief inside the community's own rules.
+12. **Sharing compounds, hoarding decays** — knowledge economics as faction physics.
+
+## Anti-patterns (hard refusals)
+
+- Closing a ledger-protected mystery "because the scene needed it."
+- Inventing an eleventh Gate, an eighth House, a new origin class, or a second true antagonist. (Closed sets are closed.)
+- Borrowed bricks: protected names, near-verbatim text, recognizable 1:1 character mappings, branded terminology from other franchises.
+- Omniscient-narrator fragments. Power without cost. Lore that exists to explain rather than to *ache*.
+- Self-promoting STAGING to LOCKED.

--- a/docs/worldbuilding/SYSTEM.md
+++ b/docs/worldbuilding/SYSTEM.md
@@ -1,0 +1,104 @@
+# SYSTEM.md — The Lore Knowledgebase Architecture
+
+> The machine-readable contract for how Arcanea (and any world built on this method) organizes canonical knowledge. Modeled on what actually works at franchise scale: a private authoritative vault, a public fragment surface, and community encyclopedias that cite fragments as primary sources.
+
+---
+
+## 1. The three layers
+
+```
+LAYER 1 — THE VAULT (private, authoritative)
+  CANON_LOCKED.md + staging docs. The "author's head-canon", written down.
+  Never shipped verbatim. Changes only through the lock gate.
+
+LAYER 2 — THE FRAGMENT SURFACE (public, diegetic)
+  Legends, item texts, character speech, songs, environmental detail.
+  Everything here has an in-world narrator and a bias. This is what
+  readers/players actually receive.
+
+LAYER 3 — THE ENCYCLOPEDIA (public, analytic)
+  Wiki-style entity pages that cite Layer 2 fragments as primary sources.
+  Speculation is quarantined and labeled. Community-editable.
+```
+
+The discipline that makes fragmentary storytelling coherent instead of sprawling: **Layer 2 may contradict itself (narrators lie); Layer 1 may not (the vault is truth).** A contradiction between fragments is a feature. A contradiction inside the vault is a bug.
+
+## 2. Canon tiers (existing Arcanea practice, formalized)
+
+| Tier | Marker | Meaning | Who can change it |
+|---|---|---|---|
+| LOCKED | ✅ | Canonical truth | Creator only, via `/lock-decision` |
+| STAGING | ⏳ | Proposed, internally consistent, awaiting promotion | Agents propose; Creator promotes |
+| EVOLVING | 🔧 | Approved concept, details flexible | Agents may extend within the concept |
+| SPECULATION | 💬 | Theories, community readings | Anyone; never cited as fact |
+
+Every lore file carries its tier in the header. Every claim in Layer 3 must be traceable to a tiered source or carry the SPECULATION label.
+
+## 3. The small ontology rule
+
+A universe stays coherent when every entity is expressible as a **stance toward ≤10 primitives**. Arcanea's primitives (all LOCKED): Lumina/Nero duality · Five Elements · Ten Gates · the Arc cycle · Seven Wisdoms · Malachar's corruption · the Gate-rank ladder.
+
+**Test for any new concept**: state it as a stance toward existing primitives in one sentence. If you can't, it's either a new primitive (rare — Creator decision) or it doesn't belong.
+
+- *Verithal* = "civilization built on Lumina's First Song where her second song (the Gates) fell silent."
+- *The Unmarred* = "renunciates who mistake the Gates themselves for Malachar's corruption."
+- *The Arbor/Dimmed* = "the covenant expression of the same belief-resonance that powers the Shadowfen seal."
+
+## 4. Fragments — the unit of delivery
+
+Author Layer-2 lore as **atoms of 1–4 sentences**, each tagged:
+
+```yaml
+fragment:
+  id: cinder-salt-choir-03
+  narrator: "Margin-port oral tradition"     # who says this, in-world
+  bias: "Hostile to the Reaches' courts"     # what the narrator wants
+  claims: [arbor.withdrawal-law.unjust]      # vault refs it bears on
+  tier_basis: STAGING                        # what it derives from
+  contradicts: [gleam-reader-testimony-01]   # deliberate tensions
+```
+
+**Redundancy rule**: every load-bearing fact appears in ≥3 independent fragments from different narrators. Assume any single consumer sees a random 20% of the corpus.
+
+## 5. Timeline by precedence, not dates
+
+Anchor events in a partial order (*X before Y because Z*), grouped into named eras (the Seven Ages → Eighth Age; within the March: Pre-Stilling → the Hush → the Thinning). Absolute dates only where structurally necessary. This keeps history extensible and preserves mystery at the edges.
+
+## 6. The naming registry (phoneme families)
+
+Names are metadata: a reader should infer faction/lineage from sound alone.
+
+| Register | Sound-space | Examples |
+|---|---|---|
+| Arcanean Gods | Liquid, open-voweled, feminine-leaning | Lyssandria, Alera, Aiyami |
+| Godbeasts | Compact, totemic | Kaelith, Otome, Kyuro |
+| Eldrian/high antiquity | -ar/-al endings, weight | Malachar, Vantara |
+| Verithal (Proof register) | Plain, workmanlike, one-or-two syllables | Ivo, Ordan Vey, Maren |
+| The Unmarred | Hard consonants, closed vowels | Kadmor Vale |
+| Places of the March | Salt/stone/work compounds | Harrow's Rest, the Salt Road |
+
+**Machine check**: new names are validated against the register before merge (no god-register names on mortals, no register collisions with the LOCKED Ten). Status-bearing name elements (the Luminor rank; "Solvane-" as founder-lineage) are *earnable and losable* — naming as plot machinery.
+
+## 7. The mystery ledger
+
+An explicit, versioned list of questions with answer budgets:
+
+- **Never answer** (load-bearing mysteries; e.g. what waits atop the Emberstair; whether an ember was ever offered to Malachar)
+- **Oblique only** (answer through contradicting narrators, never in the vault's voice)
+- **Resolvable** (fair-play questions stories may close)
+
+AI generation loves to helpfully close mysteries. The ledger is the API contract that forbids it. Ledger lives beside the vault; every lore PR is checked against it.
+
+## 8. Entity pages — two registers
+
+Every entity gets a **functional record** (mechanics, product role, stats) and a **lore record** (fragments, relationships, timeline position), linked but never merged. Dense bidirectional cross-linking: entity ↔ fragment ↔ event ↔ location. The knowledge graph is the product.
+
+## 9. Provenance & versioning
+
+- Layer 3 claims cite fragments by id (the Fandom rule, adopted wholesale: unreferenced claims are speculation and must be labeled).
+- The vault is versioned; renames and retcons carry a dated log entry (see the Godbeast rename precedent in `CANON_LOCKED.md`).
+- Translations/adaptations are tracked as variants of the fragment, not new fragments.
+
+---
+
+*Copy the architecture, never the bricks.*

--- a/docs/worldbuilding/TASTE.md
+++ b/docs/worldbuilding/TASTE.md
@@ -1,0 +1,45 @@
+# TASTE.md — Judgment the Rules Can't Capture
+
+> SYSTEM.md tells you how to organize. SKILL.md tells you what to do. This file tells you when the result is *good* — and when to delete it even though it followed every rule. The answer is usually less.
+
+---
+
+## The one test above all
+
+**Does it ache?** Great lore is not information — it is *implied loss, implied love, implied time*. A tree that is a covenant fading because people stopped believing making things matters — that aches. A tree that is a mana battery does not. If a piece only explains, cut it or bury it deeper.
+
+## The restraint tests
+
+1. **The 20% test** — delete 80% of this piece at random. Does what remains still intrigue? Fragment-lore must survive incompleteness; if it only works whole, it's an essay wearing a costume.
+2. **The narrator test** — read it aloud. Can you hear *who in the world* is saying this, and what they want from you? Voice-from-nowhere is the AI-slop tell of worldbuilding.
+3. **The explanation test** — count sentences that exist to make sure the reader "gets it." Cut them all. Trust is the genre.
+4. **The mystery test** — did this close a question that was more valuable open? (Check the ledger, then check your conscience — the ledger can't list everything.)
+5. **The stakes test** — every power has a cost, every faction an internal fault line, every belief a price. Anything free is beige.
+6. **The name test** — say the new names in sequence with the LOCKED names. Same universe? Right register? Would a reader guess the faction from sound alone?
+7. **The less test** — remove the weakest concept from the proposal entirely. Better? (It usually is. Verithal does not also need a lost fleet, a prophecy, and a secret order. One kingdom, honestly built, beats five gestured at.)
+
+## The refusal list (AI-slop patterns — reject on sight)
+
+- **The Chosen One with no bill to pay.** Arcanea's protagonists earn: rungs, vows, pilgrimages.
+- **Prophecies as plot glue.** Prophecy is allowed only as *pressure on characters*, never as causality.
+- **"Ancient beyond ancient" inflation** — the elder thing behind the elder thing. We have Lumina, Nero, and the Arbor. The set is closed.
+- **Power-scaling arms races.** Escalation must be causal and paid for (the roadmap principle), never innate spikes.
+- **Faction homogeneity** — every member believing the same thing. The Unmarred ship with Hearthkeepers, impatient young Wardens, and a founder at war with his own memory. That's minimum viable faction.
+- **Synonym-lore** — renaming a well-known thing without re-deriving it ("our Erdtree", "our Tarnished"). If the mechanism, cost, and consequence aren't re-derived from Arcanea's primitives, it's a borrowed brick with a new sticker.
+- **Wonder narrated instead of witnessed.** Don't tell the reader the lantern is miraculous; give us the villager seeing glass hold fire.
+- **Trauma as decoration.** Kadmor's burned street changes what he does. Backstory that changes nothing is wallpaper.
+- **The tidy answer.** If the theologians agree in one paragraph, rewrite until they don't.
+
+## Register notes (Arcanea voice)
+
+- Elevated but accessible; mythic but practical. Every Library text ends in a Teaching a working creator can use *today*.
+- "Arcane," not "magical/mystical." "Living universe," not "mythology." "Creator," not "user."
+- Warmth is canon. Arcanea is a hopeful universe — darkness is real (Malachar, the Dimmed courts, the burned street) but the house bet is always on making. Grimdark is off-register.
+- Humor is permitted at the margins and in the margins ("the margin ports have earned that").
+
+## The final gate
+
+Before shipping, ask the FACTIONS.md question of every addition: does it feel **inevitable, not random** — like it was always there in the world, waiting to be documented rather than invented?
+
+If yes, ship it as STAGING and let the Creator judge.
+If almost — cut a third and ask again.


### PR DESCRIPTION
## Summary
Advances the Arcanea story with three new STAGING canon systems — a civilization-reboot arc (science-and-craft narrative engine), a principled purist antagonist faction, and an exile-recalled-to-a-fading-light pilgrimage engine — plus the extracted **Worldbuilding OS** (how the best universes are systematized, operationalized for agent swarms) and the **Lore Atlas MCP** product spec. All lore is additive STAGING; `CANON_LOCKED.md` is untouched — promotion requires the Creator's `/lock-decision`.

Design lineage is declared in every doc: inspired by the *architecture* of Dr. Stone's Kingdom-of-Science engine and Elden Ring/FromSoftware's fragment method — **never the bricks**. All names, mechanisms, costs, and consequences are re-derived from Arcanea's locked primitives (research-verified IP doctrine in `docs/worldbuilding/BEST_PRACTICES.md` §IV).

## Changes
- `.arcanea/lore/KINGDOM_OF_PROOF.md` — **Verithal, the Kingdom of Proof**: the Stilling silences the Vantara March's Gates; six generations later Ivo Solvane founds a civilization on Lumina's First Song (natural law) — the Ladder of Laws, Lantern Verses, Four Hands. Connected to the Kingdom of Light via the **Concord of Two Lights**, and load-bearing for Arc 4: Proof still works if the belief-powered Gates falter.
- `.arcanea/lore/THE_UNMARRED.md` — **Kadmor Vale** and the Wardens of the Untarnished World: a principled, protective purist creed that wants the reborn March kept free of returning Gates. Structurally distinct from the Void Ascendants (comparison table included) with a full synthesis-resolution arc (the Fracture Plague → the Grey Bench).
- `.arcanea/lore/ARBOR_OF_FIRST_LIGHT.md` — the covenant tree, **the Gleam**, **the Dimmed**, the Fading (unified with Arc 4's belief-seal mechanism), and **the Returning of the Emberbearers** — a game-shaped pilgrimage-protagonist engine with an explicit mystery ledger.
- `book/legends-of-arcanea/the-stilling-and-the-first-proof.md` + `the-dimmed-and-the-returning-light.md`, `book/parables-of-creation/the-parable-of-the-unmarred.md` — three Library texts delivering the canon through diegetic narrators, each ending in a practical Teaching.
- `docs/worldbuilding/` — the **Worldbuilding OS**: `SYSTEM.md` (3-layer knowledgebase, canon tiers, fragments-with-narrators, precedence timelines, phoneme naming registry, mystery ledger), `SKILL.md` (agent procedure + gates), `AGENTS.md` (swarm roles + dispatch pipeline), `TASTE.md` (restraint tests + refusal list), `COLLABORATIONS.md` (human/AI/community protocol — anyone proposes, only the Creator locks), `BEST_PRACTICES.md` (the verified research distillation + IP doctrine).
- `docs/lore-atlas-mcp/SPEC.md` — **Lore Atlas MCP** v0.1 spec: license-clean agent access to lore encyclopedias (verified: Fandom/UESP/Tolkien Gateway/AWOIAF = CC BY-SA with open MediaWiki APIs; Fextralife = LinkOnly, content never ingested), attribution envelopes on every response, politeness layer, `compare_across_worlds` differentiator, zero-dep architecture per repo precedent (`@arcanea/swarm-coordinator`).

### Review fixes (post-review commits)
- **Intentional repo-hygiene fix**: `book/legends-of-arcanea/README.md` had *unresolved git merge-conflict markers checked into `main`* (the whole file duplicated across both halves of an old merge). Resolved deliberately: kept the half whose Guardian frequency table matches `CANON_LOCKED.md` (174–1111 Hz) and fixed its one typo (Crown Gate 714 → 741 Hz). Not an accidental rebase artifact.
- ⚠️ **Known follow-up (out of scope here)**: a repo-wide sweep found **33 more files** on `main` with the same unresolved conflict markers — most of `book/`'s READMEs and core texts, `oss/skills/arcanea/arcanea-lore/`, and `arcanea-soul/src/opencode.ts`. Each needs canon-aware resolution (the halves diverge on canon facts, e.g. Gate frequencies). Deserves a dedicated cleanup PR.
- Added the two new legends + new parable to their collections' human-facing TOCs (STAGING-labeled).
- Bumped stale hardcoded `textCount`s in `apps/web/lib/content/loader.ts` (legends 5→7, parables 1→2). Follow-up suggestion from review: derive `textCount` from the directory listing at read time to eliminate this hand-maintained counter drift.

## Type
- [ ] Feature (new functionality)
- [ ] Fix (bug fix)
- [ ] Refactor (code improvement, no behavior change)
- [x] Docs (documentation only)
- [x] Lore (universe content, Library texts)

## Checklist
- [x] TypeScript compiles with zero errors (`pnpm build`) — only TS change is two integer literals in `loader.ts`; Vercel `arcanea-web` build of this branch is green
- [x] Changes align with [ARCANEA_CANON.md](./.arcanea/lore/ARCANEA_CANON.md) (if lore-related) — additive STAGING only; Nero-is-not-evil, closed origin classes, and locked Ten all respected; no LOCKED file modified
- [x] No new `any` types introduced
- [x] Tested locally or verified in Vercel preview — `arcanea-web` preview deployed ✅. Remaining red checks are pre-existing repo CI debt unrelated to this diff: CLI test suite (175 pre-existing failures), `apps/web` lint debt (222 pre-existing errors in untouched files), `deploy-apps.yml` setup-node/pnpm ordering bug, `arcanea-2` (apps/academy) Vercel failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AomsLJvgAwwzuWph4bD7YT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added new legends and parables exploring the Arbor of First Light, the Stilling, Verithal, and the Unmarred.
  - Expanded the staged lore around factions, pilgrimages, proof-based technology, and creative belief.

- **Documentation**
  - Added comprehensive worldbuilding guidance covering collaboration, quality standards, canon management, research, and workflow.
  - Added the Lore Atlas MCP product specification.

- **Updates**
  - Updated collection listings to include the new texts.
  - Refreshed book indexes, staging sections, frequency guidance, and related references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->