### PR TITLE
docs: correct stale live-sync claim in cross-repo integration guide

### DIFF
--- a/docs/CROSS_REPOSITORY_INTEGRATION.md
+++ b/docs/CROSS_REPOSITORY_INTEGRATION.md
@@ -2,7 +2,7 @@
 
 ## 🔄 **Integration Architecture**
 
-The Arcanea ecosystem uses a **hub-and-spoke model** where the main repository serves as the central hub, and standalone repositories are *meant to be* automatically synchronized for independent deployment and development — see the current-state note below, since that sync has not actually succeeded in months.
+The Arcanea ecosystem uses a **hub-and-spoke model** where the main repository serves as the central hub, and standalone repositories are *meant to be* automatically synchronized for independent deployment and development (see current-state note below).
 
 ### Repository Structure
 

--- a/docs/CROSS_REPOSITORY_INTEGRATION.md
+++ b/docs/CROSS_REPOSITORY_INTEGRATION.md
@@ -2,7 +2,7 @@
 
 ## 🔄 **Integration Architecture**
 
-The Arcanea ecosystem uses a **hub-and-spoke model** where the main repository serves as the central hub, and standalone repositories are automatically synchronized for independent deployment and development.
+The Arcanea ecosystem uses a **hub-and-spoke model** where the main repository serves as the central hub, and standalone repositories are *meant to be* automatically synchronized for independent deployment and development — see the current-state note below, since that sync has not actually succeeded in months.
 
 ### Repository Structure
 
@@ -14,6 +14,8 @@ arcanea (main hub)
 ```
 
 ## 🤖 **Automated Synchronization**
+
+> **Current state (verified via GitHub Actions run history, 2026-07-21):** the workflow below still fires on its daily schedule, but every scheduled run has failed since 2026-02-24 — no content has actually synced to `arcanea-prompt-language` or `arcanean-library` in that window. Treat this repo and its spokes as independently maintained until the workflow is fixed and a successful run is confirmed.
 
 ### Cross-Repository Sync Workflow
 **File**: `.github/workflows/cross-repo-sync.yml`


### PR DESCRIPTION
## Summary
`docs/CROSS_REPOSITORY_INTEGRATION.md` described `cross-repo-sync.yml` as a live, automated daily sync. GitHub Actions run history (verified 2026-07-21) shows the workflow still fires on schedule but every run has failed since 2026-02-24 — no content has actually synced to `arcanea-prompt-language` or `arcanean-library` since then. This is a documentation-accuracy fix only; the workflow itself is untouched.

## Changes
- Softened the hub-and-spoke intro claim ("are automatically synchronized" → "are *meant to be* automatically synchronized ... see current-state note").
- Added an honest current-state callout under the "Automated Synchronization" heading with the verified last-success date and a "treat repos as independently maintained" caveat.

## Type
- [x] Docs (documentation only)

## Checklist
- [ ] TypeScript compiles with zero errors (`pnpm build`) — N/A, docs-only change
- [ ] Changes align with ARCANEA_CANON.md (if lore-related) — N/A
- [ ] No new `any` types introduced — N/A
- [x] Verified independently against GitHub Actions run history rather than trusting the reported staleness date at face value

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011saEKpfoKNC1JHMzAfBqmF

---
_Generated by [Claude Code](https://claude.ai/code/session_011saEKpfoKNC1JHMzAfBqmF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that standalone repositories are intended to be synchronized automatically.
  * Added a warning that cross-repository synchronization has consistently failed since February 24, 2026.
  * Advised treating affected repositories as independently maintained until synchronization succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->