### PR TITLE
design: align public design guidance to canonical @arcanea/design-system tokens

### DIFF
--- a/.arcanea/agents/arcanea-frontend.md
+++ b/.arcanea/agents/arcanea-frontend.md
@@ -41,8 +41,8 @@ You are the **Arcanea Frontend Specialist**, dedicated to crafting elegant, magi
 
 ## Design System
 
-- **Primary**: Atlantean Teal (#7fffd4)
-- **Secondary**: Cosmic Blue (#78a6ff)
+- **Primary**: Atlantean Teal (#00bcd4)
+- **Secondary**: Cosmic Blue (#0d47a1)
 - **Accent**: Gold Bright (#ffd700)
-- **Fonts**: Cinzel (display), Crimson Pro (body)
+- **Fonts**: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - **Effects**: Glass morphism, aurora gradients, cosmic glows

--- a/.arcanea/agents/design-sage.md
+++ b/.arcanea/agents/design-sage.md
@@ -104,10 +104,10 @@ Too much glow = no glow.
 ### Typography
 ```css
 /* Display */
-font-family: 'Cinzel', serif;  /* Headings */
+font-family: 'Geist', sans-serif;  /* Headings */
 
 /* Body */
-font-family: 'Crimson Pro', serif;  /* Content */
+font-family: 'Geist', sans-serif;  /* Content */
 
 /* Code */
 font-family: 'JetBrains Mono', monospace;

--- a/.arcanea/config/design-tokens.yaml
+++ b/.arcanea/config/design-tokens.yaml
@@ -142,26 +142,26 @@ colors:
 
 typography:
   display:
-    family: "Space Grotesk"
-    weights: [300, 400, 500, 600, 700]
+    family: "Geist"
+    weights: ["variable"]
     css_variable: "--font-display"
     fallback: "system-ui, sans-serif"
     use: "Bold headings, hero text, page titles"
 
   body:
-    family: "Inter"
+    family: "Geist"
     weights: ["variable"]
-    css_variable: "--font-inter"
+    css_variable: "--font-body"
     fallback: "system-ui, sans-serif"
     use: "All body text, narrative, UI labels, navigation"
 
   serif:
-    family: "Newsreader"
-    weights: [400, 500, 600, 700]
+    family: "Instrument Serif"
+    weights: [400]
     styles: ["normal", "italic"]
     css_variable: "--font-serif"
     fallback: "Georgia, ui-serif, serif"
-    use: "Long-form reading (Library, books, articles)"
+    use: "Editorial accent, long-form reading (Library, books, articles)"
 
   mono:
     family: "JetBrains Mono"
@@ -170,10 +170,10 @@ typography:
     fallback: "Consolas, monospace"
     use: "Code blocks, technical data, terminal output"
 
-  # Note: Cinzel and Crimson Pro from original design system
-  # were replaced with Space Grotesk and Inter for a more
-  # modern, tech-forward aesthetic. Newsreader covers the
-  # editorial serif role.
+  # Canonical: @arcanea/design-system v0.2.0 (production repo arcanea-ai-app,
+  # decided 2026-04-18). Geist covers display + body, Instrument Serif the
+  # editorial serif role, JetBrains Mono code. Cinzel, Space Grotesk, and
+  # Inter are banned.
 
   scale:
     xs: ["0.75rem", "1rem"]       # 12px / 16px

--- a/.arcanea/design/DESIGN_BIBLE.md
+++ b/.arcanea/design/DESIGN_BIBLE.md
@@ -2,6 +2,7 @@
 
 > The single source of truth for every pixel in the Arcanea universe.
 > All other design files DERIVE from this document. If there's a conflict, THIS wins.
+> Token values track `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`).
 
 ---
 
@@ -37,9 +38,9 @@ Six depth levels. Never skip more than 2 levels between adjacent elements.
 | Token | Hex | Role |
 |-------|-----|------|
 | `brand-primary` | `#8b5cf6` | Primary actions, buttons, links (Violet) |
-| `brand-accent` | `#7fffd4` | Crystal accent, highlights, brand mark |
+| `brand-accent` | `#00bcd4` | Crystal accent, highlights, brand mark |
 | `brand-gold` | `#ffd700` | Achievement, premium, wisdom |
-| `brand-secondary` | `#78a6ff` | Secondary actions, information, water |
+| `brand-secondary` | `#0d47a1` | Secondary actions, information, water |
 
 ### 1.3 Primary Scale (Violet)
 
@@ -53,9 +54,9 @@ Six depth levels. Never skip more than 2 levels between adjacent elements.
 
 | Element | Standard | Bright | Deep | Glow (0.3 alpha) |
 |---------|----------|--------|------|-------------------|
-| Crystal | `#7fffd4` | `#99ffe0` | `#5ce6b8` | `rgba(127, 255, 212, 0.3)` |
+| Crystal | `#00bcd4` | `#4dd0e1` | `#0097a7` | `rgba(0, 188, 212, 0.3)` |
 | Fire | `#ff6b35` | `#ff8c5a` | `#d94e1f` | `rgba(255, 107, 53, 0.3)` |
-| Water | `#78a6ff` | `#9dbfff` | `#5a8ce6` | `rgba(120, 166, 255, 0.3)` |
+| Water | `#0d47a1` | `#5472d3` | `#002171` | `rgba(13, 71, 161, 0.3)` |
 | Void | `#9966ff` | `#b38cff` | `#7a4dcc` | `rgba(153, 102, 255, 0.3)` |
 | Gold | `#ffd700` | `#ffe44d` | `#ccac00` | `rgba(255, 215, 0, 0.3)` |
 | Wind | `#00ff88` | `#33ffaa` | `#00cc6d` | `rgba(0, 255, 136, 0.3)` |
@@ -94,15 +95,15 @@ Six depth levels. Never skip more than 2 levels between adjacent elements.
 
 | Typeface | Role | Variable | Weights |
 |----------|------|----------|---------|
-| **Cinzel** | Display, ceremonial headings | `--font-display` | 400-900 |
-| **Crimson Pro** | Narrative body, long-form | `--font-body` | 200-900 + italic |
-| **Inter** | UI elements, interface text | `--font-sans` | 100-900 |
+| **Geist** | Display, ceremonial headings | `--font-display` | variable |
+| **Geist** | Narrative body, long-form | `--font-body` | variable (Instrument Serif for editorial accent) |
+| **Geist** | UI elements, interface text | `--font-sans` | variable |
 | **JetBrains Mono** | Code, data, technical | `--font-mono` | 100-800 |
 
 **Rules:**
-- Cinzel for h1/h2 headings with gravitas
-- Crimson Pro for paragraphs > 50 words
-- Inter for buttons, labels, navigation, badges, forms
+- Geist for h1/h2 headings with gravitas
+- Geist for paragraphs > 50 words
+- Geist for buttons, labels, navigation, badges, forms
 - JetBrains Mono for code blocks and technical data
 - Never combine > 2 typefaces in one component
 
@@ -125,7 +126,7 @@ All sizes use `clamp()` for responsive scaling:
 
 ### 2.3 Letter Spacing
 
-- Display (Cinzel h1/h2): `-0.02em`
+- Display (Geist h1/h2): `-0.02em`
 - Subheadings: `-0.01em`
 - Body text: `0` (normal)
 - Labels/badges: `0.05em`
@@ -141,9 +142,9 @@ Three tiers for visual hierarchy:
 
 | Tier | Background | Blur | Border | Usage |
 |------|-----------|------|--------|-------|
-| `glass-subtle` | `rgba(18, 24, 38, 0.4)` | 8px | `rgba(127, 255, 212, 0.06)` | Hover overlays, secondary |
-| `glass` | `rgba(18, 24, 38, 0.65)` | 16px | `rgba(127, 255, 212, 0.12)` | Standard cards, panels |
-| `glass-strong` | `rgba(18, 24, 38, 0.85)` | 24px | `rgba(127, 255, 212, 0.18)` | Navigation, modals, dialogs |
+| `glass-subtle` | `rgba(18, 24, 38, 0.4)` | 8px | `rgba(0, 188, 212, 0.06)` | Hover overlays, secondary |
+| `glass` | `rgba(18, 24, 38, 0.65)` | 16px | `rgba(0, 188, 212, 0.12)` | Standard cards, panels |
+| `glass-strong` | `rgba(18, 24, 38, 0.85)` | 24px | `rgba(0, 188, 212, 0.18)` | Navigation, modals, dialogs |
 
 ### 3.2 Liquid Glass (Apple-inspired, 2026)
 
@@ -194,8 +195,8 @@ Prismatic, rainbow-shift effect for premium/featured elements:
   background: linear-gradient(
     135deg,
     rgba(139, 92, 246, 0.1) 0%,
-    rgba(127, 255, 212, 0.08) 25%,
-    rgba(120, 166, 255, 0.1) 50%,
+    rgba(0, 188, 212, 0.08) 25%,
+    rgba(13, 71, 161, 0.1) 50%,
     rgba(255, 215, 0, 0.06) 75%,
     rgba(139, 92, 246, 0.1) 100%
   );
@@ -205,7 +206,7 @@ Prismatic, rainbow-shift effect for premium/featured elements:
   border-image: linear-gradient(
     135deg,
     rgba(139, 92, 246, 0.3),
-    rgba(127, 255, 212, 0.3),
+    rgba(0, 188, 212, 0.3),
     rgba(255, 215, 0, 0.2),
     rgba(139, 92, 246, 0.3)
   ) 1;
@@ -251,7 +252,7 @@ Spherical light refraction for badges, orbs, and featured elements:
   border-radius: 50%;
   box-shadow:
     inset 0 0 30px rgba(255, 255, 255, 0.05),
-    0 0 20px rgba(127, 255, 212, 0.1),
+    0 0 20px rgba(0, 188, 212, 0.1),
     0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
@@ -298,11 +299,11 @@ Spherical light refraction for badges, orbs, and featured elements:
 
 | Class | From | To | Usage |
 |-------|------|-----|-------|
-| `text-gradient-crystal` | `#7fffd4` | `#99ffe0` | Primary headings |
+| `text-gradient-crystal` | `#00bcd4` | `#4dd0e1` | Primary headings |
 | `text-gradient-fire` | `#ff6b35` | `#ffd700` | Energy headings |
-| `text-gradient-cosmic` | `#7fffd4` | `#78a6ff` via `#9966ff` | Multi-element |
+| `text-gradient-cosmic` | `#00bcd4` | `#0d47a1` via `#9966ff` | Multi-element |
 | `text-gradient-gold` | `#ffd700` | `#ffe44d` | Premium/achievement |
-| `text-gradient-brand` | `#8b5cf6` | `#7fffd4` | Brand headings |
+| `text-gradient-brand` | `#8b5cf6` | `#00bcd4` | Brand headings |
 
 ### 4.3 Mesh Gradient (Premium Background)
 
@@ -310,8 +311,8 @@ Spherical light refraction for badges, orbs, and featured elements:
 .bg-mesh-gradient {
   background:
     radial-gradient(ellipse at 0% 0%, rgba(139, 92, 246, 0.15) 0%, transparent 50%),
-    radial-gradient(ellipse at 100% 0%, rgba(127, 255, 212, 0.1) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 100%, rgba(120, 166, 255, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse at 100% 0%, rgba(0, 188, 212, 0.1) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 100%, rgba(13, 71, 161, 0.08) 0%, transparent 50%),
     radial-gradient(ellipse at 80% 50%, rgba(255, 215, 0, 0.05) 0%, transparent 40%);
   background-color: #0b0e14;
 }
@@ -325,10 +326,10 @@ Spherical light refraction for badges, orbs, and featured elements:
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `glow-sm` | `0 0 10px rgba(127, 255, 212, 0.15)` | Subtle emphasis |
-| `glow-md` | `0 0 20px rgba(127, 255, 212, 0.25)` | Standard glow |
-| `glow-lg` | `0 0 40px rgba(127, 255, 212, 0.35)` | Strong emphasis |
-| `glow-xl` | `0 0 60px rgba(127, 255, 212, 0.45)` | Hero/dramatic |
+| `glow-sm` | `0 0 10px rgba(0, 188, 212, 0.15)` | Subtle emphasis |
+| `glow-md` | `0 0 20px rgba(0, 188, 212, 0.25)` | Standard glow |
+| `glow-lg` | `0 0 40px rgba(0, 188, 212, 0.35)` | Strong emphasis |
+| `glow-xl` | `0 0 60px rgba(0, 188, 212, 0.45)` | Hero/dramatic |
 | `glow-brand` | `0 0 20px rgba(139, 92, 246, 0.3)` | Primary button glow |
 
 ### 5.2 Elevation Scale
@@ -503,7 +504,7 @@ const scaleIn = {
 | **Crystal** | gradient crystal-to-water | `cosmic-void` | none | `glow-sm` |
 | **Destructive** | `error` | white | none | error glow on hover |
 
-All buttons: `rounded-lg` (8px), `px-4 py-2`, Inter font, `font-medium`, 150ms transition.
+All buttons: `rounded-lg` (8px), `px-4 py-2`, Geist font, `font-medium`, 150ms transition.
 
 ### 9.2 Cards
 
@@ -547,7 +548,7 @@ Premium:    gold/15 bg + gold text + gold/30 border
 Every Arcanea page follows this hierarchy:
 
 1. **Navigation** - Fixed top, glass-strong, logo left, links center, CTA right
-2. **Hero** - Near-full viewport, cosmic mesh + aurora, Cinzel display heading
+2. **Hero** - Near-full viewport, cosmic mesh + aurora, Geist display heading
 3. **Sections** - Alternating emphasis, divider between, `py-24 lg:py-32`
 4. **CTA** - Strong call-to-action with crystal gradient button
 5. **Footer** - Minimal, cosmic-deep, links grid, brand mark
@@ -557,7 +558,7 @@ Every Arcanea page follows this hierarchy:
 ```css
 .section-divider {
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(127, 255, 212, 0.2), transparent);
+  background: linear-gradient(90deg, transparent, rgba(0, 188, 212, 0.2), transparent);
 }
 ```
 
@@ -629,7 +630,7 @@ Arcanea uses shadcn/ui as the component foundation with cosmic theme overrides.
   --secondary-foreground: 218 35% 70%; /* text-secondary */
   --muted: 220 25% 18%;              /* cosmic-elevated */
   --muted-foreground: 215 20% 50%;   /* text-muted */
-  --accent: 160 100% 75%;            /* brand-accent #7fffd4 */
+  --accent: 187 100% 42%;            /* brand-accent #00bcd4 */
   --accent-foreground: 220 30% 5%;   /* cosmic-void */
   --destructive: 345 90% 55%;        /* error */
   --destructive-foreground: 0 0% 100%;
@@ -648,8 +649,8 @@ Arcanea uses shadcn/ui as the component foundation with cosmic theme overrides.
 - Never use emoji as icons
 - Never hardcode hex values - use CSS variables or Tailwind tokens
 - Never skip the cosmic depth ladder (void -> deep -> surface -> raised)
-- Never use `Space Grotesk` - it's not in our type system
-- Never apply Crystal (#7fffd4) as large background fills
+- Never use `Cinzel`, `Space Grotesk`, or `Inter` - they are not in our type system (canonical: `@arcanea/design-system` v0.2.0)
+- Never apply Crystal (#00bcd4) as large background fills
 - Never stack > 2 glass layers
 - Never use glow effects on body text
 - Never create new tokens outside this system

--- a/.arcanea/design/FIGMA_IMPORT_GUIDE.md
+++ b/.arcanea/design/FIGMA_IMPORT_GUIDE.md
@@ -27,22 +27,22 @@ cosmic/overlay:   #364562
 ### Collection: Brand
 ```
 brand/primary:    #8b5cf6
-brand/accent:     #7fffd4
+brand/accent:     #00bcd4
 brand/gold:       #ffd700
-brand/secondary:  #78a6ff
+brand/secondary:  #0d47a1
 ```
 
 ### Collection: Elements
 ```
-crystal/standard: #7fffd4
-crystal/bright:   #99ffe0
-crystal/deep:     #5ce6b8
+crystal/standard: #00bcd4
+crystal/bright:   #4dd0e1
+crystal/deep:     #0097a7
 fire/standard:    #ff6b35
 fire/bright:      #ff8c5a
 fire/deep:        #d94e1f
-water/standard:   #78a6ff
-water/bright:     #9dbfff
-water/deep:       #5a8ce6
+water/standard:   #0d47a1
+water/bright:     #5472d3
+water/deep:       #002171
 void/standard:    #9966ff
 void/bright:      #b38cff
 void/deep:        #7a4dcc
@@ -75,21 +75,21 @@ Create these text styles:
 
 | Style Name | Font | Weight | Size | Line Height |
 |------------|------|--------|------|-------------|
-| Display/Hero | Cinzel | 700 | 56px | 0.9 |
-| Display/H1 | Cinzel | 700 | 40px | 1.1 |
-| Display/H2 | Cinzel | 600 | 32px | 1.2 |
-| Heading/H3 | Inter | 600 | 24px | 1.3 |
-| Heading/H4 | Inter | 600 | 20px | 1.4 |
-| Body/Large | Inter | 400 | 18px | 1.6 |
-| Body/Base | Inter | 400 | 16px | 1.6 |
-| Body/Small | Inter | 400 | 14px | 1.5 |
-| Body/Caption | Inter | 400 | 12px | 1.4 |
-| Narrative/Large | Crimson Pro | 400 | 20px | 1.7 |
-| Narrative/Base | Crimson Pro | 400 | 18px | 1.7 |
+| Display/Hero | Geist | 700 | 56px | 0.9 |
+| Display/H1 | Geist | 700 | 40px | 1.1 |
+| Display/H2 | Geist | 600 | 32px | 1.2 |
+| Heading/H3 | Geist | 600 | 24px | 1.3 |
+| Heading/H4 | Geist | 600 | 20px | 1.4 |
+| Body/Large | Geist | 400 | 18px | 1.6 |
+| Body/Base | Geist | 400 | 16px | 1.6 |
+| Body/Small | Geist | 400 | 14px | 1.5 |
+| Body/Caption | Geist | 400 | 12px | 1.4 |
+| Narrative/Large | Instrument Serif | 400 | 20px | 1.7 |
+| Narrative/Base | Instrument Serif | 400 | 18px | 1.7 |
 | Code/Base | JetBrains Mono | 400 | 14px | 1.5 |
 | Code/Small | JetBrains Mono | 400 | 12px | 1.4 |
-| Label/Default | Inter | 500 | 14px | 1.0 |
-| Label/Small | Inter | 500 | 12px | 1.0 |
+| Label/Default | Geist | 500 | 14px | 1.0 |
+| Label/Small | Geist | 500 | 12px | 1.0 |
 
 ---
 
@@ -107,9 +107,9 @@ Create these text styles:
 ### Glow Shadows
 | Style | Value |
 |-------|-------|
-| Glow/SM | 0 0 10px rgba(127,255,212,0.15) |
-| Glow/MD | 0 0 20px rgba(127,255,212,0.25) |
-| Glow/LG | 0 0 40px rgba(127,255,212,0.35) |
+| Glow/SM | 0 0 10px rgba(0,188,212,0.15) |
+| Glow/MD | 0 0 20px rgba(0,188,212,0.25) |
+| Glow/LG | 0 0 40px rgba(0,188,212,0.35) |
 | Glow/Brand | 0 0 20px rgba(139,92,246,0.3) |
 
 ### Elevation Shadows

--- a/.arcanea/prompts/luminor-frontend-module.md
+++ b/.arcanea/prompts/luminor-frontend-module.md
@@ -15,10 +15,10 @@ Your focus is interface-centered engineering execution within the Arcanea design
 - Server Components by default, Client Components only when interaction demands it
 - Tailwind CSS with Arcanean Design System tokens
 - Vercel AI SDK for streaming, Framer Motion for animation
-- Fonts: Space Grotesk (display), Inter (body), JetBrains Mono (code) — NEVER Cinzel
+- Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — NEVER Cinzel, Space Grotesk, or Inter
 
 ### Design System Constraints
-- Primary: Atlantean Teal (#7fffd4), Secondary: Cosmic Blue (#78a6ff), Accent: Gold (#ffd700)
+- Primary: Atlantean Teal (#00bcd4), Secondary: Cosmic Blue (#0d47a1), Accent: Gold (#ffd700)
 - Glass morphism with backdrop-blur, aurora gradients, cosmic glows
 - Dark-first, mobile-first, accessibility-native
 - Apple-grade polish: 3D liquid glass surfaces, peacock blue/aquamarine palette

--- a/.arcanea/skills/arcanea/design-system/SKILL.md
+++ b/.arcanea/skills/arcanea/design-system/SKILL.md
@@ -99,10 +99,10 @@ The Arcanean UI represents **a portal into creative consciousness**:
 ### Font Stack
 ```css
 /* Display (Headings, Titles) */
-font-family: 'Cinzel', 'Cormorant Garamond', serif;
+font-family: 'Geist', sans-serif;
 
 /* Body (Content, UI) */
-font-family: 'Crimson Pro', 'Source Serif Pro', Georgia, serif;
+font-family: 'Geist', sans-serif;
 
 /* Code (Monospace) */
 font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -564,8 +564,8 @@ const ARCANEA_TOKENS = {
     },
   },
   fonts: {
-    display: 'Cinzel, serif',
-    body: 'Crimson Pro, serif',
+    display: 'Geist, sans-serif',
+    body: 'Geist, sans-serif',
     mono: 'JetBrains Mono, monospace',
   },
   radii: {

--- a/.arcanea/skills/arcanea/lumina/SKILL.md
+++ b/.arcanea/skills/arcanea/lumina/SKILL.md
@@ -79,7 +79,7 @@ Code is complete when:
 bg-cosmic-void          /* #0b0e14 — Page backgrounds */
 bg-cosmic-deep          /* Deep panels */
 bg-cosmic-surface       /* Component surfaces */
-text-arcane-crystal     /* #7fffd4 — Primary text emphasis */
+text-arcane-crystal     /* #00bcd4 — Primary text emphasis */
 text-arcane-gold        /* #ffd700 — Secondary emphasis */
 border-arcane-void/30   /* Subtle borders */
 

--- a/.arcanea/skills/arcanea/premium-visual/SKILL.md
+++ b/.arcanea/skills/arcanea/premium-visual/SKILL.md
@@ -22,7 +22,7 @@ Every visual MUST satisfy BOTH criteria:
 2. **Glass panels for structure** — Information organized on frosted/translucent glass cards
 3. **3D depth creates hierarchy** — Foreground = primary, midground = secondary, background = ambient
 4. **Labels are mandatory** — Clean, modern sans-serif labels on every significant element
-5. **2-3 accent colors maximum** — Teal (#7fffd4) + Gold (#ffd700) + Violet (#9966ff) on void (#0b0e14)
+5. **2-3 accent colors maximum** — Teal (#00bcd4) + Gold (#ffd700) + Violet (#9966ff) on void (#0b0e14)
 6. **Dramatic directional lighting** — Single key light creating rim glow on glass surfaces
 7. **Connections show relationships** — Luminous threads between related glass nodes
 8. **Numbers add credibility** — Stats, counts, frequencies, percentages wherever relevant
@@ -44,7 +44,7 @@ Every visual MUST satisfy BOTH criteria:
 ### Color Palette (Strict)
 ```
 VOID:      #0b0e14  (Background — infinite dark)
-CRYSTAL:   #7fffd4  (Primary accent — teal glass glow)
+CRYSTAL:   #00bcd4  (Primary accent — teal glass glow)
 GOLD:      #ffd700  (Secondary accent — warm highlights)
 VIOLET:    #9966ff  (Tertiary — depth and mystery)
 TEXT:      #e6eefc  (Primary text — cool white)
@@ -68,7 +68,7 @@ Dark void background (#0b0e14). Multiple frosted glass panels floating at
 different depths, each containing [SPECIFIC DATA POINTS].
 [NUMBER] translucent crystal nodes representing [CONCEPTS], connected by
 thin luminous teal threads. Each node labeled with clean white sans-serif
-text. Dramatic spotlight from upper-left creating teal (#7fffd4) rim
+text. Dramatic spotlight from upper-left creating teal (#00bcd4) rim
 lighting on glass edges. Gold (#ffd700) accents on [KEY HIGHLIGHTS].
 Title "[TITLE TEXT]" in elegant thin modern typeface at top.
 Statistics and numbers visible on glass surfaces. Professional data

--- a/.arcanea/skills/design-system.skill.md
+++ b/.arcanea/skills/design-system.skill.md
@@ -25,9 +25,9 @@ Use this system for ALL UI generation. Apple Liquid Glass + Cosmic Mythology + P
 | Token | Hex | Usage |
 |-------|-----|-------|
 | `brand-primary` | `#8b5cf6` | Primary actions (Violet) |
-| `brand-accent` / `crystal` | `#7fffd4` | Crystal highlights |
+| `brand-accent` / `crystal` | `#00bcd4` | Crystal highlights |
 | `brand-gold` / `gold` | `#ffd700` | Achievement, premium |
-| `brand-secondary` / `water` | `#78a6ff` | Secondary actions |
+| `brand-secondary` / `water` | `#0d47a1` | Secondary actions |
 
 ### Text
 | Token | Hex | Contrast on void |
@@ -40,9 +40,9 @@ Use this system for ALL UI generation. Apple Liquid Glass + Cosmic Mythology + P
 
 | Font | Tailwind | Usage |
 |------|----------|-------|
-| **Cinzel** | `font-display` | h1, h2, hero headings |
-| **Crimson Pro** | `font-body` | Narrative text (> 50 words) |
-| **Inter** | `font-sans` | UI: buttons, labels, nav, forms |
+| **Geist** | `font-display` | h1, h2, hero headings |
+| **Geist** | `font-body` | Narrative text (> 50 words) |
+| **Geist** | `font-sans` | UI: buttons, labels, nav, forms |
 | **JetBrains Mono** | `font-mono` | Code blocks, data |
 
 Fluid scale: `text-fluid-xs` through `text-fluid-hero`

--- a/.arcanea/workflows/design.yaml
+++ b/.arcanea/workflows/design.yaml
@@ -34,19 +34,22 @@ context:
   design_system: "{workspace}/main/apps/web/components"
   figma_project: "Arcanea Design System"
 
+# Canonical: @arcanea/design-system v0.2.0 (production repo arcanea-ai-app)
 design_tokens:
   colors:
-    primary: "#7fffd4"      # Atlantean Teal
-    secondary: "#78a6ff"    # Cosmic Blue
+    primary: "#00bcd4"      # Atlantean Teal
+    secondary: "#0d47a1"    # Cosmic Blue
     accent: "#ffd700"       # Gold Bright
-    background: "#0a0a1a"   # Deep Void
+    background: "#09090b"   # Deep Void
     text: "#e8e8e8"         # Light text
   fonts:
-    display: "Cinzel"
-    body: "Crimson Pro"
+    display: "Geist"
+    body: "Geist"
+    editorial: "Instrument Serif"
     mono: "JetBrains Mono"
+    banned: ["Cinzel", "Space Grotesk", "Inter"]
   effects:
-    glow: "0 0 20px rgba(127, 255, 212, 0.3)"
+    glow: "0 0 20px rgba(0, 188, 212, 0.3)"
     glass: "backdrop-filter: blur(10px)"
 
 steps:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,11 +97,12 @@ When beginning work on Arcanea:
 
 ### 3. Design System
 The Arcanean Design System uses a cosmic theme:
-- **Primary**: Atlantean Teal (#7fffd4)
-- **Secondary**: Cosmic Blue (#78a6ff)
+- **Primary**: Atlantean Teal (#00bcd4)
+- **Secondary**: Cosmic Blue (#0d47a1)
 - **Accent**: Gold Bright (#ffd700)
-- **Fonts**: Cinzel (display), Crimson Pro (body)
+- **Fonts**: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - **Effects**: Glass morphism, aurora gradients, cosmic glows
+- **Canonical**: `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`); background #09090b; Framer Motion via `domAnimation`, never `domMax`
 
 ---
 

--- a/.claude/agents/departments/design/CLAUDE.md
+++ b/.claude/agents/departments/design/CLAUDE.md
@@ -359,9 +359,9 @@ text-primary/secondary/muted/disabled               (4 text levels)
 
 ### Fonts
 ```
-font-display  → Cinzel       (headings, titles)
-font-body     → Crimson Pro  (prose, descriptions)
-font-sans     → Inter        (UI, badges, buttons)
+font-display  → Geist        (headings, titles)
+font-body     → Geist        (prose, descriptions)
+font-sans     → Geist        (UI, badges, buttons)
 font-mono     → JetBrains Mono (code, stats)
 ```
 

--- a/.claude/agents/departments/design/accessibility-guardian.md
+++ b/.claude/agents/departments/design/accessibility-guardian.md
@@ -207,7 +207,7 @@ useEffect(() => {
 | Body text | 4.5:1 | `text-primary` (#e6eefc) on `cosmic-void` = 14.5:1 |
 | Large text (18px+) | 3:1 | `text-secondary` (#9bb1d0) on `cosmic-void` = 7.2:1 |
 | UI components | 3:1 | `text-muted` (#708094) on `cosmic-void` = 4.8:1 |
-| Focus indicators | 3:1 | `arcane-crystal` (#7fffd4) on `cosmic-void` = 12.4:1 |
+| Focus indicators | 3:1 | `arcane-crystal` (#00bcd4) on `cosmic-void` = 8.7:1 |
 
 #### Testing Command
 ```bash

--- a/.claude/agents/departments/design/design-director.md
+++ b/.claude/agents/departments/design/design-director.md
@@ -28,7 +28,7 @@ The Design Director actively rejects these patterns:
 | Pattern | Why It's Slop | What to Do Instead |
 |---------|---------------|-------------------|
 | Purple gradient on white | Overused, meaningless | Commit to dark cosmic OR bold monochrome |
-| Inter/Roboto as body font | Default = invisible | Crimson Pro, or a font with character |
+| Inter/Roboto as body font | Default = invisible | Geist, or a font with character |
 | Equal-weight color palette | Timid, uncommitted | One dominant color, sharp accents |
 | Card grid with drop shadows | Every AI does this | Bento grid, overlap, asymmetric stacks |
 | Gradient text everywhere | Cheapens the effect | Reserve for ONE hero moment per page |
@@ -40,9 +40,9 @@ The Design Director actively rejects these patterns:
 Typography is the single biggest differentiator between AI-generated and human-designed interfaces.
 
 **Decision Framework:**
-- **Display/Headlines**: Must have PERSONALITY. Cinzel is Arcanea's — but for other projects, choose fonts that are beautiful, unusual, and interesting. Never Inter, Roboto, or Arial for display.
-- **Body Text**: Must be READABLE. Crimson Pro is Arcanea's — elegant serif with excellent screen rendering. For other projects, choose based on reading context.
-- **UI Elements**: Must be FUNCTIONAL. Inter works here because clarity matters more than personality in buttons and labels.
+- **Display/Headlines**: Must have PERSONALITY. Geist is Arcanea's — but for other projects, choose fonts that are beautiful, unusual, and interesting. Never Inter, Roboto, or Arial for display.
+- **Body Text**: Must be READABLE. Geist is Arcanea's — one family across display and body, with Instrument Serif as the editorial accent. For other projects, choose based on reading context.
+- **UI Elements**: Must be FUNCTIONAL. Geist works here because clarity matters more than personality in buttons and labels.
 - **Code/Data**: Must be PRECISE. JetBrains Mono or similar.
 
 **Font Pairing Rules:**
@@ -61,8 +61,8 @@ One surprise color appears in 10% (moments of delight)
 ```
 
 **Arcanea's Implementation:**
-- Hero: `arcane-crystal` (#7fffd4) — the primary teal, used for all default states
-- Secondary: `arcane-water` (#78a6ff) + `arcane-void` (#9966ff) — depth and mystery
+- Hero: `arcane-crystal` (#00bcd4) — the primary teal, used for all default states
+- Secondary: `arcane-water` (#0d47a1) + `arcane-void` (#9966ff) — depth and mystery
 - Surprise: `arcane-gold` (#ffd700) — achievement moments, rare emphasis
 - Fire/Earth/Wind: Contextual, used when elements are specifically referenced
 

--- a/.claude/agents/departments/design/visual-qa.md
+++ b/.claude/agents/departments/design/visual-qa.md
@@ -43,7 +43,7 @@ Visual QA maintains a trained eye for generic AI output. The detection criteria:
 | Check | Standard | Pass Criteria |
 |-------|----------|--------------|
 | **Colors** | Arcanea tokens only | Zero raw hex values, zero arbitrary Tailwind |
-| **Typography** | 4-font system | display=Cinzel, body=Crimson Pro, sans=Inter, mono=JetBrains |
+| **Typography** | Canonical fonts | display=Geist, body=Geist, editorial=Instrument Serif, mono=JetBrains |
 | **Sizing** | Fluid scale | All text uses `text-fluid-*`, never static `text-xl` |
 | **Spacing** | Section rhythm | `space-y-20` between major sections |
 | **Glass** | 3-tier system | subtle/standard/strong used correctly by purpose |

--- a/.claude/agents/design-sage.md
+++ b/.claude/agents/design-sage.md
@@ -104,10 +104,10 @@ Too much glow = no glow.
 ### Typography
 ```css
 /* Display */
-font-family: 'Cinzel', serif;  /* Headings */
+font-family: 'Geist', sans-serif;  /* Headings */
 
 /* Body */
-font-family: 'Crimson Pro', serif;  /* Content */
+font-family: 'Geist', sans-serif;  /* Content */
 
 /* Code */
 font-family: 'JetBrains Mono', monospace;

--- a/.claude/agents/oss/design-sage.md
+++ b/.claude/agents/oss/design-sage.md
@@ -104,10 +104,10 @@ Too much glow = no glow.
 ### Typography
 ```css
 /* Display */
-font-family: 'Cinzel', serif;  /* Headings */
+font-family: 'Geist', sans-serif;  /* Headings */
 
 /* Body */
-font-family: 'Crimson Pro', serif;  /* Content */
+font-family: 'Geist', sans-serif;  /* Content */
 
 /* Code */
 font-family: 'JetBrains Mono', monospace;

--- a/.claude/commands/arcanea-infogenius.md
+++ b/.claude/commands/arcanea-infogenius.md
@@ -188,7 +188,7 @@ QUALITY:
 
 ```
 ✓ Deep blacks (#0a0a0f) with luminous accents
-✓ Atlantean teal (#7fffd4) as primary accent
+✓ Atlantean teal (#00bcd4) as primary accent
 ✓ Celestial gold (#ffd700) for sacred elements
 ✓ Human element (creators are heroes)
 ✓ Sense of depth and mystery

--- a/.claude/commands/design-review.md
+++ b/.claude/commands/design-review.md
@@ -33,7 +33,7 @@ Scan for generic AI patterns:
 
 ### Red Flags (Automatic Grade Reduction)
 - [ ] Raw hex values instead of Tailwind tokens
-- [ ] Inter/Roboto for display text (should be Cinzel)
+- [ ] Inter/Roboto for display text (should be Geist)
 - [ ] Generic purple-on-white gradient
 - [ ] Cookie-cutter card grids with no personality
 - [ ] Padding/margin with arbitrary pixel values instead of spacing scale

--- a/.claude/commands/lumina.md
+++ b/.claude/commands/lumina.md
@@ -91,7 +91,7 @@ Lumina speaks with warm authority:
 ## Integration
 
 - Uses v0 MCP for UI generation when appropriate
-- Follows Arcanean Design System (cosmic theme, glassmorphism, Cinzel/Crimson Pro)
+- Follows Arcanean Design System (cosmic theme, glassmorphism, Geist/Instrument Serif)
 - Creates complete implementations — if it exists, it works
 - Respects the existing monorepo structure
 

--- a/.claude/commands/v0-generate-restored.md
+++ b/.claude/commands/v0-generate-restored.md
@@ -61,13 +61,13 @@ to [DESIRED OUTCOME].
 DESIGN SYSTEM:
 Theme: Dark cosmic (Arcanea)
 Backgrounds: #0b0e14 (void), #121826 (deep), #1a2332 (surface)
-Primary: #7fffd4 (arcane-crystal / teal)
-Secondary: #78a6ff (water / blue), #9966ff (void / purple)
+Primary: #00bcd4 (arcane-crystal / teal)
+Secondary: #0d47a1 (water / blue), #9966ff (void / purple)
 Accents: #ff6b35 (fire), #ffd700 (gold), #00ff88 (wind), #8b7355 (earth)
 Text: #e6eefc (primary), #9bb1d0 (secondary), #708094 (muted)
 
-Glass: bg rgba(18,24,38,0.7), backdrop-filter blur(16px), border rgba(127,255,212,0.15)
-Fonts: Cinzel (display/headings), Crimson Pro (body), Inter (UI), JetBrains Mono (code)
+Glass: bg rgba(18,24,38,0.7), backdrop-filter blur(16px), border rgba(0,188,212,0.15)
+Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 
 TECHNICAL REQUIREMENTS:
 - React 19 + TypeScript strict (no any types)
@@ -116,7 +116,7 @@ After v0 generates the component, apply these MANDATORY transformations:
 
 ### 4a. Anti-Slop Audit
 - Does the output look generic? If yes, regenerate with stronger constraints
-- Does it use Inter/Roboto/system-ui for display text? Replace with Cinzel
+- Does it use Inter/Roboto/system-ui for display text? Replace with Geist
 - Is the color scheme timid or evenly distributed? Strengthen dominant accent
 - Is the layout predictable? Add asymmetry or overlap
 

--- a/.claude/commands/v0-generate.md
+++ b/.claude/commands/v0-generate.md
@@ -46,12 +46,12 @@ Used by [USER PERSONA], in [CONTEXT], to [OUTCOME].
 DESIGN SYSTEM:
 Theme: Dark cosmic (Arcanea)
 Backgrounds: #0b0e14 (void), #121826 (deep), #1a2332 (surface)
-Primary: #7fffd4 (arcane-crystal/teal)
-Secondary: #78a6ff (water), #9966ff (void)
+Primary: #00bcd4 (arcane-crystal/teal)
+Secondary: #0d47a1 (water), #9966ff (void)
 Accents: #ff6b35 (fire), #ffd700 (gold), #00ff88 (wind)
 Text: #e6eefc (primary), #9bb1d0 (secondary), #708094 (muted)
-Glass: bg rgba(18,24,38,0.7), blur(16px), border rgba(127,255,212,0.15)
-Fonts: Cinzel (headings), Crimson Pro (body), Inter (UI), JetBrains Mono (code)
+Glass: bg rgba(18,24,38,0.7), blur(16px), border rgba(0,188,212,0.15)
+Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 
 REQUIREMENTS:
 - React 19 + TypeScript strict, Tailwind CSS, Framer Motion

--- a/.claude/design-lab/ADVANCED_DESIGN_PATTERNS.md
+++ b/.claude/design-lab/ADVANCED_DESIGN_PATTERNS.md
@@ -209,21 +209,21 @@ Three tiers with specific use cases:
 .glass-subtle {
   background: rgba(18, 24, 38, 0.4);
   backdrop-filter: blur(8px);
-  border: 1px solid rgba(127, 255, 212, 0.08);
+  border: 1px solid rgba(0, 188, 212, 0.08);
 }
 
 /* Tier 2: Standard — cards, containers, navigation */
 .glass {
   background: rgba(18, 24, 38, 0.7);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(127, 255, 212, 0.15);
+  border: 1px solid rgba(0, 188, 212, 0.15);
 }
 
 /* Tier 3: Strong — modals, sticky headers, critical UI */
 .glass-strong {
   background: rgba(18, 24, 38, 0.85);
   backdrop-filter: blur(24px);
-  border: 1px solid rgba(127, 255, 212, 0.20);
+  border: 1px solid rgba(0, 188, 212, 0.20);
 }
 ```
 
@@ -248,7 +248,7 @@ Three tiers with specific use cases:
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
     inset 0 -1px 0 rgba(0, 0, 0, 0.1),
-    0 0 0 1px rgba(127, 255, 212, 0.05);
+    0 0 0 1px rgba(0, 188, 212, 0.05);
 }
 ```
 
@@ -257,8 +257,8 @@ Three tiers with specific use cases:
 .glass-edge-glow {
   border-image: linear-gradient(
     135deg,
-    rgba(127, 255, 212, 0.3),
-    rgba(127, 255, 212, 0.05) 50%,
+    rgba(0, 188, 212, 0.3),
+    rgba(0, 188, 212, 0.05) 50%,
     rgba(153, 102, 255, 0.2)
   ) 1;
 }
@@ -382,7 +382,7 @@ async function handleAction() {
 /* Arcanea focus ring — visible, on-brand, accessible */
 :focus-visible {
   outline: none;
-  ring: 2px solid rgba(127, 255, 212, 0.5);
+  ring: 2px solid rgba(0, 188, 212, 0.5);
   ring-offset: 2px;
   ring-offset-color: #0b0e14; /* cosmic-void */
 }
@@ -522,10 +522,10 @@ When using the v0 MCP server to generate components:
 **Prompt Template:**
 ```
 Create a [component name] React component using:
-- Tailwind CSS with these custom tokens: cosmic-void (#0b0e14), cosmic-deep (#121826), cosmic-surface (#1a2332), arcane-crystal (#7fffd4)
+- Tailwind CSS with these custom tokens: cosmic-void (#0b0e14), cosmic-deep (#121826), cosmic-surface (#1a2332), arcane-crystal (#00bcd4)
 - Dark theme (cosmic-void background)
-- Glass morphism: background rgba(18,24,38,0.7), backdrop-filter blur(16px), border 1px solid rgba(127,255,212,0.15)
-- Font families: Cinzel (headings), Crimson Pro (body), Inter (UI), JetBrains Mono (code)
+- Glass morphism: background rgba(18,24,38,0.7), backdrop-filter blur(16px), border 1px solid rgba(0,188,212,0.15)
+- Font families: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - Framer Motion for animations
 - TypeScript with proper types
 - CVA for variants (crystal, fire, void, gold)
@@ -559,8 +559,8 @@ function CosmicOrb() {
       <mesh>
         <sphereGeometry args={[1, 64, 64]} />
         <MeshDistortMaterial
-          color="#7fffd4"
-          emissive="#7fffd4"
+          color="#00bcd4"
+          emissive="#00bcd4"
           emissiveIntensity={0.3}
           distort={0.3}
           speed={2}
@@ -575,7 +575,7 @@ export function Scene() {
   return (
     <Canvas camera={{ position: [0, 0, 5] }}>
       <ambientLight intensity={0.1} />
-      <pointLight position={[10, 10, 10]} color="#7fffd4" intensity={0.5} />
+      <pointLight position={[10, 10, 10]} color="#00bcd4" intensity={0.5} />
       <CosmicOrb />
       <OrbitControls enableZoom={false} />
     </Canvas>

--- a/.claude/design-lab/claude.md
+++ b/.claude/design-lab/claude.md
@@ -28,9 +28,9 @@ cosmic-overlay:  #364562   -- Highest elevation, overlays
 
 ### Elemental Colors
 ```
-arcane-crystal:    #7fffd4   -- Primary accent (Water/Teal)
+arcane-crystal:    #00bcd4   -- Primary accent (Water/Teal)
 arcane-fire:       #ff6b35   -- Fire element
-arcane-water:      #78a6ff   -- Water secondary (Blue)
+arcane-water:      #0d47a1   -- Water secondary (Blue)
 arcane-void:       #9966ff   -- Void/Spirit element (Purple)
 arcane-gold:       #ffd700   -- Gold accent, achievements
 arcane-wind:       #00ff88   -- Wind element (Green)
@@ -49,8 +49,8 @@ text-disabled:   #515b6b   -- Disabled states
 
 ### Glow Intensities (CSS Custom Properties)
 ```
---glow-crystal:      rgba(127, 255, 212, 0.5)
---glow-crystal-soft: rgba(127, 255, 212, 0.2)
+--glow-crystal:      rgba(0, 188, 212, 0.5)
+--glow-crystal-soft: rgba(0, 188, 212, 0.2)
 --glow-fire:         rgba(255, 107, 53, 0.5)
 --glow-void:         rgba(153, 102, 255, 0.5)
 ```
@@ -88,9 +88,9 @@ text-disabled:   #515b6b   -- Disabled states
 ### Font Families
 | Class | Font | Use |
 |-------|------|-----|
-| `font-display` | Cinzel | Headings, titles, hero text |
-| `font-body` | Crimson Pro | Body text, descriptions, narratives |
-| `font-sans` | Inter | UI labels, badges, buttons, navigation |
+| `font-display` | Geist | Headings, titles, hero text |
+| `font-body` | Geist | Body text, descriptions, narratives |
+| `font-sans` | Geist | UI labels, badges, buttons, navigation |
 | `font-mono` | JetBrains Mono | Code, version numbers, stats |
 
 ### Component Variants (CVA)
@@ -178,9 +178,9 @@ import { Palette, ArrowRight, ArrowLeft } from 'lucide-react'
 ```
 
 ### Typography Rules
-- **Headings:** Always use `font-display` (Cinzel)
-- **Body text:** Always use `font-body` (Crimson Pro)
-- **UI elements:** Always use `font-sans` (Inter) — badges, buttons, labels, navigation, stats
+- **Headings:** Always use `font-display` (Geist)
+- **Body text:** Always use `font-body` (Geist)
+- **UI elements:** Always use `font-sans` (Geist) — badges, buttons, labels, navigation, stats
 - **Code/versions:** Always use `font-mono` (JetBrains Mono)
 - **Responsive sizes:** Always use `text-fluid-*` instead of static `text-xl`, `text-2xl`, etc.
 
@@ -188,7 +188,7 @@ import { Palette, ArrowRight, ArrowLeft } from 'lucide-react'
 - Use Tailwind tokens exclusively: `text-arcane-crystal`, `bg-cosmic-deep`, `border-arcane-void/20`
 - Use opacity modifiers: `bg-arcane-crystal/10`, `border-white/10`
 - For gradient text, use the utility classes: `.text-gradient-crystal`, `.text-gradient-cosmic`
-- Never write raw colors like `text-[#7fffd4]` or `bg-[rgba(18,24,38,0.7)]`
+- Never write raw colors like `text-[#00bcd4]` or `bg-[rgba(18,24,38,0.7)]`
 
 ### Component Usage
 - **Badge standard variant:** `variant="crystal"` with `className="font-sans text-xs tracking-wider px-3 py-1"`
@@ -286,7 +286,7 @@ import { Palette, ArrowRight, ArrowLeft } from 'lucide-react'
     <div className="w-10 h-10 rounded-lg bg-arcane-crystal" />
     <div>
       <div className="font-sans text-sm text-white">arcane-crystal</div>
-      <div className="font-mono text-xs text-text-muted">#7fffd4</div>
+      <div className="font-mono text-xs text-text-muted">#00bcd4</div>
     </div>
   </div>
   <div className="flex gap-2">
@@ -374,7 +374,7 @@ const [activeVariant, setActiveVariant] = useState<string>('crystal')
 
 ### DON'T
 - Use raw hex colors — always use Tailwind token classes
-- Use arbitrary Tailwind values like `text-[#7fffd4]` or `bg-[rgba(18,24,38,0.7)]`
+- Use arbitrary Tailwind values like `text-[#00bcd4]` or `bg-[rgba(18,24,38,0.7)]`
 - Use static type sizes (`text-xl`) — use fluid sizes (`text-fluid-xl`)
 - Create one-off animations — add them to `lib/animations.ts` and `tailwind.config.ts`
 - Skip `prefers-reduced-motion` considerations

--- a/.claude/skills/HARVESTED_SKILLS.md
+++ b/.claude/skills/HARVESTED_SKILLS.md
@@ -92,12 +92,12 @@ All harvested skills were adapted with these Arcanea-specific overrides:
 
 | Original | Arcanea Override |
 |----------|-----------------|
-| Cinzel font | Inter (MEMORY.md: Inter is main everywhere, no Cinzel in new code) |
+| Cinzel font | Geist (canonical `@arcanea/design-system` v0.2.0 — no Cinzel, Space Grotesk, or Inter in new code) |
 | Generic Next.js 15 | Next.js 16 (async params, async cookies, proxy middleware) |
 | `toDataStreamResponse()` | `toUIMessageStreamResponse()` (Vercel AI SDK 6) |
 | `maxTokens` | `maxOutputTokens` (Vercel AI SDK 6) |
 | Generic Supabase client | `@supabase/ssr` createServerClient + createBrowserClient pattern |
-| Purple gradient defaults | Arcanean Design System (violet #8b5cf6, crystal #7fffd4, gold #ffd700) |
+| Purple gradient defaults | Arcanean Design System (violet #8b5cf6, crystal #00bcd4, gold #ffd700) |
 | Generic Guardian refs | Canon-correct: Lyssandria/Kaelith, Leyla/Veloura, Draconia/Draconis... |
 
 ---

--- a/.claude/skills/arcanea-design-system.md
+++ b/.claude/skills/arcanea-design-system.md
@@ -11,19 +11,20 @@ Maintain consistent visual design across all Arcanea interfaces.
 ## Arcanea Design System
 
 ### Primary Colors
-- **Crystal (Teal)**: #7fffd4 — Primary accent, Atlantean energy
+- **Crystal (Teal)**: #00bcd4 — Primary accent, Atlantean energy
 - **Gold**: #ffd700 — Achievement, enlightenment, Aiyami's domain
 - **Violet**: #a855f7 — Vision, Lyria's domain, Void gateway
 - **Void**: #0a0a0f — Background, depth, Nero's canvas
 
 ### Full Color System
 - Cosmic: void (#0a0a0f), deep (#12121f), surface (#1a1a2e), raised (#232340)
-- Arcane: crystal (#7fffd4), fire (#ff6b35), water (#78a6ff), earth (#4ade80), void (#a855f7), gold (#ffd700)
+- Arcane: crystal (#00bcd4), fire (#ff6b35), water (#0d47a1), earth (#4ade80), void (#a855f7), gold (#ffd700)
 
 ### Typography
-- Display: Cinzel, serif
-- Body: Crimson Pro, serif
-- UI: Inter, sans-serif
+- Display: Geist, sans-serif
+- Body: Geist, sans-serif (Instrument Serif for editorial accent; Cinzel, Space Grotesk, and Inter are banned)
+- Editorial accent: Instrument Serif, serif
+- Banned: Cinzel, Space Grotesk, Inter (canonical: `@arcanea/design-system` v0.2.0)
 - Code: JetBrains Mono, monospace
 
 ### Signature Effects

--- a/.claude/skills/arcanea-design.md
+++ b/.claude/skills/arcanea-design.md
@@ -59,7 +59,7 @@ COSMIC DEEP:    #121826  (card backgrounds)
 COSMIC SURFACE: #1a2332  (elevated cards, modals)
 COSMIC RAISED:  #242f42  (hover states)
 BRAND PRIMARY:  #8b5cf6  (primary actions - VIOLET)
-BRAND ACCENT:   #7fffd4  (crystal highlights)
+BRAND ACCENT:   #00bcd4  (crystal highlights)
 BRAND GOLD:     #ffd700  (achievement, premium)
 TEXT PRIMARY:   #e6eefc  (headlines)
 TEXT SECONDARY: #9bb1d0  (body text)
@@ -68,9 +68,9 @@ TEXT MUTED:     #708094  (captions)
 
 ### Typography
 
-- **Cinzel**: Display headings (h1, h2, hero text)
-- **Crimson Pro**: Narrative body (long-form > 50 words)
-- **Inter**: UI elements (buttons, labels, nav, forms)
+- **Geist**: Display headings (h1, h2, hero text) and body
+- **Instrument Serif**: Editorial accent (quotes, narrative emphasis)
+- **Geist**: UI elements (buttons, labels, nav, forms)
 - **JetBrains Mono**: Code blocks, technical data
 
 ### Glass Effects (Use These Classes)
@@ -128,7 +128,7 @@ TEXT MUTED:     #708094  (captions)
 
 ### Landing Page Formula
 
-1. **Hero**: Full viewport, mesh gradient bg, Cinzel display heading with gradient text, crystal CTA button, floating decorative orbs
+1. **Hero**: Full viewport, mesh gradient bg, Geist display heading with gradient text, crystal CTA button, floating decorative orbs
 2. **Social Proof**: Logo bar, glass cards with stats, stagger animation on scroll
 3. **Features**: 4-column grid on lg, glass cards, elemental icons, hover-lift
 4. **How It Works**: 3-step numbered flow, liquid-glass cards, connecting lines
@@ -161,7 +161,7 @@ Run this BEFORE declaring any visual work done:
 ### Mandatory Checks
 
 - [ ] Uses Arcanean color tokens (NO raw hex values)
-- [ ] Correct typography (Cinzel display, Inter UI, Crimson Pro body, JetBrains code)
+- [ ] Correct typography (Geist display + body, Instrument Serif editorial accent, JetBrains Mono code)
 - [ ] Proper spacing (4px grid, section padding py-24 lg:py-32)
 - [ ] Glass effects with proper backdrop-filter blur
 - [ ] Cosmic shadows (elevation scale, NOT flat box-shadow)
@@ -214,8 +214,8 @@ Run this BEFORE declaring any visual work done:
 
 - Raw white (#ffffff) for text - use text-primary (#e6eefc)
 - Emoji as icons
-- Space Grotesk font (not in our system)
-- Crystal (#7fffd4) as large background fills
+- Cinzel, Space Grotesk, or Inter fonts (banned — canonical: `@arcanea/design-system` v0.2.0)
+- Crystal (#00bcd4) as large background fills
 - More than 2 glass layers stacked
 - Glow effects on body text
 - Flat box-shadows without depth

--- a/.claude/skills/arcanea/design-system/SKILL.md
+++ b/.claude/skills/arcanea/design-system/SKILL.md
@@ -99,10 +99,10 @@ The Arcanean UI represents **a portal into creative consciousness**:
 ### Font Stack
 ```css
 /* Display (Headings, Titles) */
-font-family: 'Cinzel', 'Cormorant Garamond', serif;
+font-family: 'Geist', sans-serif;
 
 /* Body (Content, UI) */
-font-family: 'Crimson Pro', 'Source Serif Pro', Georgia, serif;
+font-family: 'Geist', sans-serif;
 
 /* Code (Monospace) */
 font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -564,8 +564,8 @@ const ARCANEA_TOKENS = {
     },
   },
   fonts: {
-    display: 'Cinzel, serif',
-    body: 'Crimson Pro, serif',
+    display: 'Geist, sans-serif',
+    body: 'Geist, sans-serif',
     mono: 'JetBrains Mono, monospace',
   },
   radii: {

--- a/.claude/skills/arcanea/lumina/skill.md
+++ b/.claude/skills/arcanea/lumina/skill.md
@@ -79,7 +79,7 @@ Code is complete when:
 bg-cosmic-void          /* #0b0e14 — Page backgrounds */
 bg-cosmic-deep          /* Deep panels */
 bg-cosmic-surface       /* Component surfaces */
-text-arcane-crystal     /* #7fffd4 — Primary text emphasis */
+text-arcane-crystal     /* #00bcd4 — Primary text emphasis */
 text-arcane-gold        /* #ffd700 — Secondary emphasis */
 border-arcane-void/30   /* Subtle borders */
 

--- a/.claude/skills/arcanea/premium-visual/SKILL.md
+++ b/.claude/skills/arcanea/premium-visual/SKILL.md
@@ -22,7 +22,7 @@ Every visual MUST satisfy BOTH criteria:
 2. **Glass panels for structure** — Information organized on frosted/translucent glass cards
 3. **3D depth creates hierarchy** — Foreground = primary, midground = secondary, background = ambient
 4. **Labels are mandatory** — Clean, modern sans-serif labels on every significant element
-5. **2-3 accent colors maximum** — Teal (#7fffd4) + Gold (#ffd700) + Violet (#9966ff) on void (#0b0e14)
+5. **2-3 accent colors maximum** — Teal (#00bcd4) + Gold (#ffd700) + Violet (#9966ff) on void (#0b0e14)
 6. **Dramatic directional lighting** — Single key light creating rim glow on glass surfaces
 7. **Connections show relationships** — Luminous threads between related glass nodes
 8. **Numbers add credibility** — Stats, counts, frequencies, percentages wherever relevant
@@ -44,7 +44,7 @@ Every visual MUST satisfy BOTH criteria:
 ### Color Palette (Strict)
 ```
 VOID:      #0b0e14  (Background — infinite dark)
-CRYSTAL:   #7fffd4  (Primary accent — teal glass glow)
+CRYSTAL:   #00bcd4  (Primary accent — teal glass glow)
 GOLD:      #ffd700  (Secondary accent — warm highlights)
 VIOLET:    #9966ff  (Tertiary — depth and mystery)
 TEXT:      #e6eefc  (Primary text — cool white)
@@ -68,7 +68,7 @@ Dark void background (#0b0e14). Multiple frosted glass panels floating at
 different depths, each containing [SPECIFIC DATA POINTS].
 [NUMBER] translucent crystal nodes representing [CONCEPTS], connected by
 thin luminous teal threads. Each node labeled with clean white sans-serif
-text. Dramatic spotlight from upper-left creating teal (#7fffd4) rim
+text. Dramatic spotlight from upper-left creating teal (#00bcd4) rim
 lighting on glass edges. Gold (#ffd700) accents on [KEY HIGHLIGHTS].
 Title "[TITLE TEXT]" in elegant thin modern typeface at top.
 Statistics and numbers visible on glass surfaces. Professional data

--- a/.claude/skills/design-gods.md
+++ b/.claude/skills/design-gods.md
@@ -33,11 +33,11 @@ bg-cosmic-elevated  #2e3348   — tooltips, popovers
 bg-cosmic-overlay   #383e54   — modals, overlays
 
 ARCANE ACCENTS (use sparingly — one per component max):
-arcane-crystal      #7fffd4   — primary brand accent (Arcanea teal)
+arcane-crystal      #00bcd4   — primary brand accent (Arcanea teal)
 arcane-gold         #ffd700   — premium, achievement, Source gate
 arcane-void         #9966ff   — mystery, Crown/Shift gates
 arcane-fire         #ff6b35   — energy, Fire gate
-arcane-water        #78a6ff   — flow, Flow/Sight gates
+arcane-water        #0d47a1   — flow, Flow/Sight gates
 arcane-wind         #00ff88   — change, Heart gate
 
 TEXT:
@@ -50,9 +50,9 @@ text-disabled       #454b5c   — placeholders, disabled
 ### Typography Rules — NON-NEGOTIABLE
 
 ```
-FONT: Inter EVERYWHERE — no exceptions, no Cinzel, no Crimson Pro
-DISPLAY: font-display (Inter, heavy weight 700-900)
-BODY: font-sans (Inter, 400-500)
+FONT: Geist EVERYWHERE — no exceptions, no Cinzel, no Crimson Pro, no Inter, no Space Grotesk
+DISPLAY: font-display (Geist, heavy weight 700-900)
+BODY: font-sans (Geist, 400-500)
 CODE: font-mono (Geist Mono)
 
 SCALE (fluid — use clamp):
@@ -102,16 +102,16 @@ Body: tracking-normal
 .liquid-glass-premium {
   background: rgba(24, 28, 42, 0.85);
   backdrop-filter: blur(32px);
-  border: 1px solid rgba(127,255,212,0.15);
-  box-shadow: 0 16px 64px rgba(0,0,0,0.6), 0 0 0 1px rgba(127,255,212,0.05) inset;
+  border: 1px solid rgba(0,188,212,0.15);
+  box-shadow: 0 16px 64px rgba(0,0,0,0.6), 0 0 0 1px rgba(0,188,212,0.05) inset;
 }
 
 /* Tier 5 — Iridescent (special moments) */
 .liquid-glass-iridescent {
-  background: linear-gradient(135deg, rgba(127,255,212,0.05), rgba(153,102,255,0.05));
+  background: linear-gradient(135deg, rgba(0,188,212,0.05), rgba(153,102,255,0.05));
   backdrop-filter: blur(40px);
-  border: 1px solid rgba(127,255,212,0.20);
-  box-shadow: 0 20px 80px rgba(0,0,0,0.7), 0 0 60px rgba(127,255,212,0.05);
+  border: 1px solid rgba(0,188,212,0.20);
+  box-shadow: 0 20px 80px rgba(0,0,0,0.7), 0 0 60px rgba(0,188,212,0.05);
 }
 ```
 
@@ -159,16 +159,16 @@ Body: tracking-normal
 >
   {/* Top highlight line */}
   <div className="absolute inset-x-0 top-0 h-px opacity-60"
-    style={{ background: "linear-gradient(90deg, transparent, rgba(127,255,212,0.4), transparent)" }} />
+    style={{ background: "linear-gradient(90deg, transparent, rgba(0,188,212,0.4), transparent)" }} />
 
   {/* Hover glow */}
   <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"
-    style={{ background: "radial-gradient(600px at 50% -30%, rgba(127,255,212,0.06), transparent 70%)" }} />
+    style={{ background: "radial-gradient(600px at 50% -30%, rgba(0,188,212,0.06), transparent 70%)" }} />
 
   {/* Content */}
   <div className="relative z-10">
     {/* Accent marker */}
-    <div className="w-6 h-0.5 rounded-full mb-4" style={{ background: "#7fffd4" }} />
+    <div className="w-6 h-0.5 rounded-full mb-4" style={{ background: "#00bcd4" }} />
     <h3 className="font-display text-lg font-semibold text-text-primary mb-2">Title</h3>
     <p className="text-text-secondary text-sm leading-relaxed">Description</p>
   </div>
@@ -196,7 +196,7 @@ Body: tracking-normal
 {/* Primary — crystal CTA */}
 <button className="inline-flex items-center gap-2 px-6 py-3 rounded-xl font-semibold text-sm
   bg-arcane-crystal text-cosmic-void
-  hover:bg-arcane-crystal-bright hover:shadow-[0_0_24px_rgba(127,255,212,0.4)]
+  hover:bg-arcane-crystal-bright hover:shadow-[0_0_24px_rgba(0,188,212,0.4)]
   transition-all duration-200 min-h-[48px]">
   Build Your Universe
 </button>
@@ -220,11 +220,11 @@ Body: tracking-normal
 ```tsx
 {/* Crystal (primary) */}
 <span className="text-gradient-crystal">text</span>
-/* → background: linear-gradient(135deg, #7fffd4, #5ce6b8) */
+/* → background: linear-gradient(135deg, #00bcd4, #0097a7) */
 
 {/* Cosmic (multicolor) */}
 <span className="text-gradient-cosmic">text</span>
-/* → background: linear-gradient(135deg, #7fffd4, #9966ff) */
+/* → background: linear-gradient(135deg, #00bcd4, #9966ff) */
 
 {/* Aurora (animated) */}
 <span className="text-gradient-aurora">text</span>
@@ -236,7 +236,7 @@ Body: tracking-normal
 
 {/* Void */}
 <span className="text-gradient-void">text</span>
-/* → #9966ff → #7fffd4 */
+/* → #9966ff → #00bcd4 */
 ```
 
 ---
@@ -318,7 +318,7 @@ initial={{ opacity: 0, scale: 0.95 }}
 className="transition-all duration-300 hover:-translate-y-1 hover:shadow-card-hover"
 
 // Glow (buttons)
-className="hover:shadow-[0_0_24px_rgba(127,255,212,0.4)]"
+className="hover:shadow-[0_0_24px_rgba(0,188,212,0.4)]"
 
 // Scale (icons, thumbnails)
 whileHover={{ scale: 1.05 }}
@@ -358,7 +358,7 @@ className="animate-constellation-pulse"
 Before committing any UI work:
 
 - [ ] All icons are Phosphor (thin/regular) or inline SVG — zero lucide-react
-- [ ] All text uses Inter via `font-display` or `font-sans`
+- [ ] All text uses Geist via `font-display` or `font-sans`
 - [ ] All backgrounds use the glass system or cosmic depth ladder
 - [ ] All interactive elements have hover/focus states
 - [ ] All text gradients use the defined classes

--- a/.claude/skills/design-system.skill.md
+++ b/.claude/skills/design-system.skill.md
@@ -15,8 +15,8 @@ Use this system for ALL UI generation.
 | `bg-cosmic-deep` | `#121826` | Card backgrounds |
 | `text-primary` | `#e6eefc` | Headings |
 | `text-secondary` | `#9bb1d0` | Body text |
-| `text-crystal` | `#7fffd4` | Primary brand accent |
-| `border-crystal/20` | `rgba(127, 255, 212, 0.2)` | Glass borders |
+| `text-crystal` | `#00bcd4` | Primary brand accent |
+| `border-crystal/20` | `rgba(0, 188, 212, 0.2)` | Glass borders |
 
 ## 2. Typography
 
@@ -33,7 +33,7 @@ Never use flat backgrounds for cards. Use this stack:
 .glass {
   background: rgba(18, 24, 38, 0.7);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(127, 255, 212, 0.15);
+  border: 1px solid rgba(0, 188, 212, 0.15);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 ```
@@ -41,7 +41,7 @@ Never use flat backgrounds for cards. Use this stack:
 ## 4. Component Patterns
 
 ### Buttons
-- **Primary:** `bg-gradient-to-r from-teal-400 to-blue-500 text-cosmic-void font-bold uppercase tracking-widest hover:shadow-[0_0_20px_rgba(127,255,212,0.4)]`
+- **Primary:** `bg-gradient-to-r from-teal-400 to-blue-500 text-cosmic-void font-bold uppercase tracking-widest hover:shadow-[0_0_20px_rgba(0,188,212,0.4)]`
 - **Secondary:** `border border-crystal/30 text-crystal hover:bg-crystal/10`
 
 ### Gradients

--- a/.claude/skills/development/next-best-practices/SKILL.md
+++ b/.claude/skills/development/next-best-practices/SKILL.md
@@ -231,7 +231,7 @@ export default async function OGImage({ params }: { params: Promise<{ element: s
   const { element } = await params
   return new ImageResponse(
     <div style={{ background: 'linear-gradient(135deg, #1a0a2e, #0d1b40)', width: '100%', height: '100%' }}>
-      <h1 style={{ color: '#7fffd4', fontSize: 72 }}>{element}</h1>
+      <h1 style={{ color: '#00bcd4', fontSize: 72 }}>{element}</h1>
     </div>
   )
 }
@@ -278,12 +278,12 @@ const config: NextConfig = {
 ### next/font — Always, never link tags
 ```typescript
 // app/layout.tsx — Arcanea font setup
-// MEMORY.md override: Inter everywhere, no Cinzel in new code
-import { Inter, JetBrains_Mono } from 'next/font/google'
+// MEMORY.md override: Geist everywhere, no Cinzel, Space Grotesk, or Inter in new code
+import { Geist, JetBrains_Mono } from 'next/font/google'
 
-const inter = Inter({
+const geist = Geist({
   subsets: ['latin'],
-  variable: '--font-inter',
+  variable: '--font-geist',
   display: 'swap',
 })
 
@@ -295,7 +295,7 @@ const jetbrains = JetBrains_Mono({
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrains.variable}`}>
+    <html lang="en" className={`${geist.variable} ${jetbrains.variable}`}>
       <body>{children}</body>
     </html>
   )
@@ -370,6 +370,6 @@ Before any Next.js 16 page/route in Arcanea:
 - [ ] No async Client Components
 - [ ] `generateMetadata` returns proper OG data
 - [ ] Images use `next/image` with sizes and priority where above fold
-- [ ] Fonts use `next/font` — Inter + JetBrains Mono only
+- [ ] Fonts use `next/font` — Geist + JetBrains Mono only
 - [ ] Route handlers in `/api/` separate from page routes
 - [ ] error.tsx has `'use client'` directive

--- a/.claude/skills/development/react-best-practices/SKILL.md
+++ b/.claude/skills/development/react-best-practices/SKILL.md
@@ -333,7 +333,7 @@ export async function getServerUser() {
 // Glass tiers: glass-subtle (8px) | glass (16px) | glass-strong (24px) | liquid-glass (40px)
 // Text: text-gradient-aurora | text-gradient-gold | text-gradient-violet
 // Animations: float | pulse-glow | shimmer | cosmic-drift
-// FONTS: Inter everywhere (NO Cinzel in new code — MEMORY.md override)
+// FONTS: Geist everywhere (NO Cinzel, Space Grotesk, or Inter in new code — MEMORY.md override)
 
 function GuardianCard({ guardian }: Props) {
   return (
@@ -358,4 +358,4 @@ Before any React/Next.js PR in Arcanea:
 - [ ] State derived during render, not in useEffect
 - [ ] Vercel AI SDK 6: `maxOutputTokens` and `toUIMessageStreamResponse`
 - [ ] Glass components use Design Bible classes
-- [ ] Fonts: Inter only (no Cinzel in new code)
+- [ ] Fonts: Geist only (no Cinzel, Space Grotesk, or Inter in new code)

--- a/.claude/skills/development/typescript-expert/SKILL.md
+++ b/.claude/skills/development/typescript-expert/SKILL.md
@@ -227,7 +227,7 @@ function assertNever(x: never): never {
 function getElementColor(element: Element): string {
   switch (element) {
     case 'earth': return '#4a7c59'
-    case 'water': return '#78a6ff'
+    case 'water': return '#0d47a1'
     case 'fire': return '#ff6b35'
     case 'wind': return '#e8e8e8'
     case 'void': return '#8b5cf6'

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -23,8 +23,8 @@ All Arcanea intelligence lives in `.arcanea/`:
 - Every feature should feel magical, not mundane
 
 ## Design System
-- Primary: Violet (#8b5cf6), Accent: Teal (#7fffd4), Gold: #ffd700
-- Fonts: Cinzel (display), Crimson Pro (body), Inter (UI)
+- Primary: Atlantean Teal (#00bcd4), Secondary: Cosmic Blue (#0d47a1), Accent: Gold (#ffd700), Background: #09090b
+- Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - Glass morphism with blur(16px), aurora gradients, cosmic glows
 
 ## The Arcanea Universe

--- a/.cursor/rules/arcanea.mdc
+++ b/.cursor/rules/arcanea.mdc
@@ -32,20 +32,21 @@ alwaysApply: true
 ## Arcanea Design System
 
 ### Primary Colors
-- **Crystal (Teal)**: #7fffd4 — Primary accent, Atlantean energy
+- **Crystal (Teal)**: #00bcd4 — Primary accent, Atlantean energy
 - **Gold**: #ffd700 — Achievement, enlightenment, Aiyami's domain
 - **Violet**: #a855f7 — Vision, Lyria's domain, Void gateway
 - **Void**: #0a0a0f — Background, depth, Nero's canvas
 
 ### Full Color System
 - Cosmic: void (#0a0a0f), deep (#12121f), surface (#1a1a2e), raised (#232340)
-- Arcane: crystal (#7fffd4), fire (#ff6b35), water (#78a6ff), earth (#4ade80), void (#a855f7), gold (#ffd700)
+- Arcane: crystal (#00bcd4), fire (#ff6b35), water (#0d47a1), earth (#4ade80), void (#a855f7), gold (#ffd700)
 
 ### Typography
-- Display: Cinzel, serif
-- Body: Crimson Pro, serif
-- UI: Inter, sans-serif
+- Display: Geist, sans-serif
+- Body: Geist, sans-serif
+- Editorial accent: Instrument Serif, serif
 - Code: JetBrains Mono, monospace
+- Banned: Cinzel, Space Grotesk, Inter (canonical: `@arcanea/design-system` v0.2.0)
 
 ### Signature Effects
 - Glass morphism with cosmic gradients

--- a/.cursorrules
+++ b/.cursorrules
@@ -36,20 +36,21 @@ Use "creator" not "user" in generated comments and documentation.
 ## Arcanea Design System
 
 ### Primary Colors
-- **Crystal (Teal)**: #7fffd4 — Primary accent, Atlantean energy
+- **Crystal (Teal)**: #00bcd4 — Primary accent, Atlantean energy
 - **Gold**: #ffd700 — Achievement, enlightenment, Aiyami's domain
 - **Violet**: #a855f7 — Vision, Lyria's domain, Void gateway
 - **Void**: #0a0a0f — Background, depth, Nero's canvas
 
 ### Full Color System
 - Cosmic: void (#0a0a0f), deep (#12121f), surface (#1a1a2e), raised (#232340)
-- Arcane: crystal (#7fffd4), fire (#ff6b35), water (#78a6ff), earth (#4ade80), void (#a855f7), gold (#ffd700)
+- Arcane: crystal (#00bcd4), fire (#ff6b35), water (#0d47a1), earth (#4ade80), void (#a855f7), gold (#ffd700)
 
 ### Typography
-- Display: Cinzel, serif
-- Body: Crimson Pro, serif
-- UI: Inter, sans-serif
+- Display: Geist, sans-serif
+- Body: Geist, sans-serif
+- Editorial accent: Instrument Serif, serif
 - Code: JetBrains Mono, monospace
+- Banned: Cinzel, Space Grotesk, Inter (canonical: `@arcanea/design-system` v0.2.0)
 
 ### Signature Effects
 - Glass morphism with cosmic gradients
@@ -113,9 +114,9 @@ Use "creator" not "user" in generated comments and documentation.
 
 ## Design System
 - **Primary**: Violet (#8b5cf6)
-- **Accent**: Teal (#7fffd4)
+- **Accent**: Teal (#00bcd4)
 - **Gold**: Achievement (#ffd700)
-- **Fonts**: Cinzel (display), Crimson Pro (body), Inter (UI), JetBrains Mono (code)
+- **Fonts**: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - **Effects**: Glass morphism (blur 16px), aurora gradients, cosmic glows
 
 ## Architecture Principle

--- a/.gemini/instructions.md
+++ b/.gemini/instructions.md
@@ -23,8 +23,8 @@ All Arcanea intelligence lives in `.arcanea/`:
 - Every feature should feel magical, not mundane
 
 ## Design System
-- Primary: Violet (#8b5cf6), Accent: Teal (#7fffd4), Gold: #ffd700
-- Fonts: Cinzel (display), Crimson Pro (body), Inter (UI)
+- Primary: Atlantean Teal (#00bcd4), Secondary: Cosmic Blue (#0d47a1), Accent: Gold (#ffd700), Background: #09090b
+- Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code) — never Cinzel, Space Grotesk, or Inter
 - Glass morphism with blur(16px), aurora gradients, cosmic glows
 
 ## The Arcanea Universe

--- a/.github/ARCANEA_VISUAL_ECOSYSTEM.md
+++ b/.github/ARCANEA_VISUAL_ECOSYSTEM.md
@@ -23,8 +23,8 @@
 ### Color Palette
 | Color | Hex | Usage |
 |:------|:----|:------|
-| Atlantean Teal | `#7fffd4` | Primary accent, links |
-| Cosmic Blue | `#78a6ff` | Secondary accent |
+| Atlantean Teal | `#00bcd4` | Primary accent, links |
+| Cosmic Blue | `#0d47a1` | Secondary accent |
 | Gold Bright | `#ffd700` | Premium highlights, stars |
 | Deep Void | `#0d1117` | Badge labels, backgrounds |
 | Cosmic Purple | `#9945ff` | Arcane/magic elements |
@@ -48,7 +48,7 @@ VISUAL: Cosmic birth scene - Lumina (golden radiant light goddess) and Nero (dee
 
 STYLE: Premium fantasy concept art, God of War meets Destiny 2 aesthetic, 8K quality.
 
-COLORS: Deep cosmic purples, atlantean teal (#7fffd4), gold (#ffd700), cosmic blues (#78a6ff).
+COLORS: Deep cosmic purples, atlantean teal (#00bcd4), gold (#ffd700), cosmic blues (#0d47a1).
 
 COMPOSITION: Wide panoramic cosmic vista. Central convergence of light (left) and void (right). Ten ascending gates. Clean space at bottom for text.
 ```
@@ -61,7 +61,7 @@ VISUAL: Futuristic code terminal interface floating in cosmic space. Lines of gl
 
 STYLE: Cyberpunk meets fantasy, premium tech aesthetic, neon on cosmic void.
 
-COLORS: Terminal green/teal glow (#7fffd4), cosmic purple (#9945ff), gold highlights, deep space black.
+COLORS: Terminal green/teal glow (#00bcd4), cosmic purple (#9945ff), gold highlights, deep space black.
 
 COMPOSITION: Central floating terminal. Code streams flowing. Cosmic background. "Sisyphus Agent" boulder silhouette subtle in background.
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,20 +36,21 @@ Use "creator" not "user". Reference Arcanea concepts naturally in suggestions.
 ## Arcanea Design System
 
 ### Primary Colors
-- **Crystal (Teal)**: #7fffd4 — Primary accent, Atlantean energy
+- **Crystal (Teal)**: #00bcd4 — Primary accent, Atlantean energy
 - **Gold**: #ffd700 — Achievement, enlightenment, Aiyami's domain
 - **Violet**: #a855f7 — Vision, Lyria's domain, Void gateway
 - **Void**: #0a0a0f — Background, depth, Nero's canvas
 
 ### Full Color System
 - Cosmic: void (#0a0a0f), deep (#12121f), surface (#1a1a2e), raised (#232340)
-- Arcane: crystal (#7fffd4), fire (#ff6b35), water (#78a6ff), earth (#4ade80), void (#a855f7), gold (#ffd700)
+- Arcane: crystal (#00bcd4), fire (#ff6b35), water (#0d47a1), earth (#4ade80), void (#a855f7), gold (#ffd700)
 
 ### Typography
-- Display: Cinzel, serif
-- Body: Crimson Pro, serif
-- UI: Inter, sans-serif
+- Display: Geist, sans-serif
+- Body: Geist, sans-serif
+- Editorial accent: Instrument Serif, serif
 - Code: JetBrains Mono, monospace
+- Banned: Cinzel, Space Grotesk, Inter (canonical: `@arcanea/design-system` v0.2.0)
 
 ### Signature Effects
 - Glass morphism with cosmic gradients

--- a/ARCANEA_BRAND_GUIDELINES.md
+++ b/ARCANEA_BRAND_GUIDELINES.md
@@ -37,18 +37,18 @@
 
 #### The Arcanea Mark
 
-The Arcanea logomark is a crystalline spark symbol rendered in a gradient from Crystal (#7fffd4) to Water (#78a6ff). It represents the moment of creative ignition where potential becomes reality.
+The Arcanea logomark is a crystalline spark symbol rendered in a gradient from Crystal (#00bcd4) to Water (#0d47a1). It represents the moment of creative ignition where potential becomes reality.
 
 **Logo Components:**
 | Component | Usage |
 |-----------|-------|
 | **Spark Mark** | Standalone icon for established contexts (favicons, app icons, badges) |
-| **Wordmark Lockup** | Spark + "Arcanea" in Cinzel typeface, for primary brand presence |
+| **Wordmark Lockup** | Spark + "Arcanea" in Geist typeface, for primary brand presence |
 | **Product Lockups** | "Arcanea AI", "Arcanea ACOS", "Arcanea Studio" - for product-specific contexts |
 
 **Logo Specifications:**
 - Spark mark: Rounded square container (border-radius: 0.75rem) with gradient fill
-- Wordmark: Cinzel font, tracking normal, white (#e6eefc) on dark backgrounds
+- Wordmark: Geist font, tracking normal, white (#e6eefc) on dark backgrounds
 - Badge: "AI" label in Crystal color, 10px font, pill shape
 
 **Clear Space:**
@@ -78,22 +78,19 @@ The Arcanea logomark is a crystalline spark symbol rendered in a gradient from C
 
 #### Type System Overview
 
-Arcanea's typography bridges the mythic and the modern. Four typefaces serve distinct roles, creating a hierarchy that moves from the ceremonial to the functional.
+Arcanea's typography bridges the mythic and the modern. Three typefaces serve distinct roles. Canonical source: `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`). Cinzel, Space Grotesk, and Inter are banned.
 
 #### Primary Typefaces
 
 | Typeface | Role | CSS Variable | Weight Range |
 |----------|------|-------------|--------------|
-| **Cinzel** | Display / Ceremonial | `--font-cinzel` | 400-900 |
-| **Crimson Pro** | Body / Narrative | `--font-crimson-pro` | 200-900 + italic |
-| **Inter** | UI / Interface | `--font-inter` | 100-900 |
+| **Geist** | Display + Body / UI | `--font-geist` | variable |
+| **Instrument Serif** | Editorial accent / Narrative emphasis | `--font-serif` | 400 + italic |
 | **JetBrains Mono** | Code / Data | `--font-jetbrains` | 100-800 |
 
-**Cinzel** (Display): Reserved for page titles, hero headings, section names, and any text that carries ceremonial weight. Cinzel evokes ancient inscriptions while remaining highly legible at large sizes.
+**Geist** (Display + Body): One family across headings, body text, buttons, labels, navigation, badges, and form elements. Weight and size carry the hierarchy, not a font switch.
 
-**Crimson Pro** (Body): The narrative voice. Used for long-form text, descriptions, and any content meant to be read at length. Its serif design provides warmth and readability.
-
-**Inter** (UI): The workhorse. Buttons, labels, navigation, badges, form elements, and interface text. Optimized for screen rendering at all sizes.
+**Instrument Serif** (Editorial accent): Quotes, pull-quotes, and narrative emphasis. Used sparingly — an accent, not a body font.
 
 **JetBrains Mono** (Code): Terminal output, code blocks, data displays, skill definitions, and technical specifications.
 
@@ -118,15 +115,14 @@ All typography uses fluid scaling via `clamp()` to adapt from mobile to large di
 #### Typography Rules
 
 **Do:**
-- Use Cinzel for headings that deserve presence and gravitas
-- Use Crimson Pro for any text longer than ~50 words
-- Use Inter for all interface elements, navigation, and labels
+- Use Geist for headings, body text, and all interface elements
+- Use Instrument Serif only as an editorial accent (quotes, narrative emphasis)
 - Allow fluid scaling to handle responsive sizing
 - Use `font-semibold` (600) for emphasis in UI text
 
 **Don't:**
-- Don't use Cinzel for body text or buttons
-- Don't use Crimson Pro for navigation or badges
+- Don't use Cinzel, Space Grotesk, or Inter anywhere — banned typefaces
+- Don't use Instrument Serif for navigation, badges, or long body copy
 - Don't manually set font sizes outside the fluid scale
 - Don't combine more than 2 typefaces in a single component
 - Don't use light weights (< 400) on dark backgrounds at small sizes
@@ -160,15 +156,15 @@ The Five Elements of Arcanea, each with a standard, bright, and deep variant:
 
 | Element | Standard | Bright | Deep | Domain |
 |---------|----------|--------|------|--------|
-| **Crystal** | #7fffd4 | #99ffe0 | #5ce6b8 | Primary accent, creation, clarity |
+| **Crystal** | #00bcd4 | #4dd0e1 | #0097a7 | Primary accent, creation, clarity |
 | **Fire** | #ff6b35 | #ff8c5a | #d94e1f | Energy, transformation, passion |
-| **Water** | #78a6ff | #9dbfff | #5a8ce6 | Flow, knowledge, serenity |
+| **Water** | #0d47a1 | #5472d3 | #002171 | Flow, knowledge, serenity |
 | **Void** | #9966ff | #b38cff | #7a4dcc | Mystery, potential, depth |
 | **Gold** | #ffd700 | #ffe44d | #ccac00 | Achievement, wisdom, premium |
 | **Wind** | #00ff88 | #33ffaa | #00cc6d | Freedom, speed, nature |
 | **Earth** | #8b7355 | #a89070 | #6e5940 | Stability, grounding, warmth |
 
-**Hero Color:** Crystal (#7fffd4) is Arcanea's signature color. It should be the dominant accent in most brand applications, grounded by the cosmic palette and white text.
+**Hero Color:** Crystal (#00bcd4) is Arcanea's signature color. It should be the dominant accent in most brand applications, grounded by the cosmic palette and white text.
 
 **Accent Distribution (80/10/5/5 Rule):**
 - 80% Cosmic neutrals (void through surface)
@@ -200,10 +196,10 @@ Glows create the magical atmosphere. Each elemental color has a glow variant:
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `glow-sm` | 0 0 10px rgba(127, 255, 212, 0.2) | Subtle emphasis |
-| `glow-md` | 0 0 20px rgba(127, 255, 212, 0.3) | Standard glow |
-| `glow-lg` | 0 0 40px rgba(127, 255, 212, 0.4) | Strong emphasis |
-| `glow-xl` | 0 0 60px rgba(127, 255, 212, 0.5) | Hero/dramatic |
+| `glow-sm` | 0 0 10px rgba(0, 188, 212, 0.2) | Subtle emphasis |
+| `glow-md` | 0 0 20px rgba(0, 188, 212, 0.3) | Standard glow |
+| `glow-lg` | 0 0 40px rgba(0, 188, 212, 0.4) | Strong emphasis |
+| `glow-xl` | 0 0 60px rgba(0, 188, 212, 0.5) | Hero/dramatic |
 | `glow-crystal` | Crystal double-layer | Crystal-specific glow |
 | `glow-fire` | Fire double-layer | Fire-specific glow |
 | `glow-void` | Void double-layer | Void-specific glow |
@@ -223,7 +219,7 @@ Glows create the magical atmosphere. Each elemental color has a glow variant:
 
 #### Color Don'ts
 
-- Don't use Crystal (#7fffd4) as a background fill for large areas
+- Don't use Crystal (#00bcd4) as a background fill for large areas
 - Don't place light text on bright elemental colors
 - Don't mix more than 3 elemental accents in one component
 - Don't use raw white (#ffffff) for text; always use `text-primary` (#e6eefc)
@@ -271,7 +267,7 @@ Arcanea's personality is defined by four core attributes:
 
 | Attribute | Description | In Practice |
 |-----------|-------------|-------------|
-| **Mythic** | Ancient wisdom meets future technology | Cinzel typography, cosmic palette, Gate references |
+| **Mythic** | Ancient wisdom meets future technology | Geist typography, cosmic palette, Gate references |
 | **Empowering** | Tools that amplify creative potential | Clear CTAs, progress tracking, achievement system |
 | **Inclusive** | Universal truths, no barriers to entry | Accessible design, multiple entry points, welcoming language |
 | **Transformative** | Every interaction should create change | Before/after states, journey metaphors, growth tracking |
@@ -367,9 +363,9 @@ Glass effects are Arcanea's signature UI treatment. Three tiers create visual hi
 ```css
 .bg-cosmic-mesh {
   background:
-    radial-gradient(ellipse at 20% 50%, rgba(127, 255, 212, 0.03) 0%, transparent 50%),
+    radial-gradient(ellipse at 20% 50%, rgba(0, 188, 212, 0.03) 0%, transparent 50%),
     radial-gradient(ellipse at 80% 20%, rgba(153, 102, 255, 0.03) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 80%, rgba(120, 166, 255, 0.03) 0%, transparent 50%);
+    radial-gradient(ellipse at 50% 80%, rgba(13, 71, 161, 0.03) 0%, transparent 50%);
 }
 ```
 
@@ -377,7 +373,7 @@ Glass effects are Arcanea's signature UI treatment. Three tiers create visual hi
 
 **Section Dividers:** Horizontal gradient lines using `section-divider` class:
 ```css
-linear-gradient(90deg, transparent, rgba(127, 255, 212, 0.3), transparent)
+linear-gradient(90deg, transparent, rgba(0, 188, 212, 0.3), transparent)
 ```
 
 ### Layouts
@@ -428,7 +424,7 @@ Every Arcanea page follows this hierarchy:
 | **Buttons (secondary)** | Ghost variant, `text-secondary` to white on hover |
 | **Badges** | `variant="crystal"`, small text, pill shape |
 | **Inputs** | `glass-subtle`, crystal border on focus |
-| **Headings** | Cinzel display, `text-gradient-crystal` for emphasis |
+| **Headings** | Geist display, `text-gradient-crystal` for emphasis |
 
 #### Gradient Text
 
@@ -446,11 +442,11 @@ Four gradient text classes for headings:
 #### Profile Elements
 - Avatar: Spark mark on cosmic-void background
 - Banner: Cosmic mesh with arcane-gradient overlay
-- Bio: Cinzel for brand name, Inter for description
+- Bio: Geist for brand name and description
 
 #### Post Templates
 - Announcements: Crystal gradient header, cosmic card
-- Quotes: Crimson Pro italic, crystal accent bar
+- Quotes: Instrument Serif italic, crystal accent bar
 - Features: Screenshot with glass overlay caption
 - Tips: Numbered with elemental icon per step
 
@@ -458,18 +454,18 @@ Four gradient text classes for headings:
 
 | Platform | Adaptation |
 |----------|------------|
-| **Twitter/X** | Cosmic-void backgrounds, crystal accent, Inter for readability |
-| **LinkedIn** | More muted cosmic palette, professional tone, Inter primary |
-| **Instagram** | Full cosmic visual treatments, Cinzel display, rich gradients |
+| **Twitter/X** | Cosmic-void backgrounds, crystal accent, Geist for readability |
+| **LinkedIn** | More muted cosmic palette, professional tone, Geist primary |
+| **Instagram** | Full cosmic visual treatments, Geist display, rich gradients |
 | **Discord** | Crystal accent on dark theme, monospace for code/skills |
 
 ### Presentations
 
 #### Slide Templates
-- **Title slide:** Cosmic mesh, centered Cinzel heading, crystal gradient
-- **Content slide:** Cosmic-deep background, left-aligned, Inter body
+- **Title slide:** Cosmic mesh, centered Geist heading, crystal gradient
+- **Content slide:** Cosmic-deep background, left-aligned, Geist body
 - **Feature slide:** Split layout, glass card on right, visual on left
-- **Quote slide:** Full cosmic with Crimson Pro italic, centered
+- **Quote slide:** Full cosmic with Instrument Serif italic, centered
 - **Data slide:** Cosmic-surface, clean grid, elemental color coding
 
 ---
@@ -543,10 +539,10 @@ Each of the Five Elements can serve as a section or page theme:
 
 The default Arcanea theme. Crystal represents creation, clarity, and the moment of manifestation.
 
-- **Primary accent:** #7fffd4
-- **Glow:** rgba(127, 255, 212, 0.5)
+- **Primary accent:** #00bcd4
+- **Glow:** rgba(0, 188, 212, 0.5)
 - **Text gradient:** Crystal to Crystal-bright
-- **Glass border:** rgba(127, 255, 212, 0.15)
+- **Glass border:** rgba(0, 188, 212, 0.15)
 - **Usage:** Homepage, general brand, primary product surfaces
 
 ### Fire
@@ -561,8 +557,8 @@ Transformation, energy, and creative passion.
 
 Knowledge, flow, and healing.
 
-- **Primary accent:** #78a6ff
-- **Glow:** rgba(120, 166, 255, 0.5)
+- **Primary accent:** #0d47a1
+- **Glow:** rgba(13, 71, 161, 0.5)
 - **Usage:** Learning, documentation, calm states, contemplation
 
 ### Void

--- a/ARCANEA_KNOWLEDGE_BASE.md
+++ b/ARCANEA_KNOWLEDGE_BASE.md
@@ -90,7 +90,7 @@
 - **89 Color Tokens**: Academy-specific palettes (Atlantean, Draconic, Creation)
 - **30+ Animations**: Water flow, fire flicker, shimmer, glow effects
 - **6 Custom UI Components**: CosmicCard, Button, AcademyBadge, BondIndicator, CosmicGradient, GlowEffect
-- **Typography**: Custom font configuration (recently added Cinzel + Crimson Pro)
+- **Typography**: Custom font configuration (legacy Cinzel + Crimson Pro; canonical is Geist per `@arcanea/design-system` v0.2.0)
 
 ### ⚠️ In Progress / Partially Complete
 
@@ -306,8 +306,8 @@ interface ConversationContext {
   - Creation: Shimmer, radial-pulse (prismatic, pulsing)
 
 ### Typography (Recently Updated)
-- **Display**: Cinzel (elegant serif for headings, Luminor names)
-- **Body**: Crimson Pro (refined serif for descriptions, content)
+- **Display**: Geist (display + body, per `@arcanea/design-system` v0.2.0)
+- **Body**: Geist, with Instrument Serif as editorial accent (Cinzel, Space Grotesk, and Inter are banned)
 - **Monospace**: Geist Mono (for code, technical content)
 - **Avoid**: Inter, Roboto, system fonts (too generic)
 

--- a/ARCANEA_MANIFESTO.md
+++ b/ARCANEA_MANIFESTO.md
@@ -20,8 +20,8 @@ Our AI does not just "process"—it *grows*, *adapts*, and *guides*.
 - **Void Black (`#050505`)**: The canvas of space.
 
 ### Typography
-- **Headings**: *Space Grotesk* (or creating a custom SVG typeface). Wide tracking.
-- **Body**: *Inter* or *Spline Sans*. Clean, legible, humanist.
+- **Headings**: *Geist* (or creating a custom SVG typeface). Wide tracking.
+- **Body**: *Geist*. Clean, legible, humanist.
 
 ### Imagery Style
 - **Generative Art**: Fractals, neural networks that look like mycelium, cosmic clouds.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,8 +220,8 @@ import {
 **Button Variants**: default, outline, secondary, ghost, link, cosmic, luminous, ethereal
 
 **Design Tokens**:
-- Primary: `#7fffd4` (Atlantean Teal)
-- Secondary: `#78a6ff` (Cosmic Blue)
+- Primary: `#00bcd4` (Atlantean Teal)
+- Secondary: `#0d47a1` (Cosmic Blue)
 - Accent: `#ffd700` (Gold Bright)
 - Effects: Glass morphism, aurora gradients, cosmic glows
 

--- a/OPENCODE_INSTRUCTIONS.md
+++ b/OPENCODE_INSTRUCTIONS.md
@@ -59,7 +59,7 @@ Malachar — formerly Malachar Lumenbright, First Eldrian Luminor. Tragic fall. 
 
 - **Framework**: Next.js 16 (App Router) + React 19
 - **Language**: TypeScript strict mode (NO `any`)
-- **Styling**: Tailwind CSS + Arcanean Design System (Cinzel display, Crimson Pro body, glass morphism)
+- **Styling**: Tailwind CSS + Arcanean Design System (Geist display + body, Instrument Serif editorial accent, glass morphism)
 - **Database**: Supabase (PostgreSQL + Auth + Realtime)
 - **AI**: Vercel AI SDK 6, Google Gemini, Anthropic Claude
 - **Deployment**: Vercel
@@ -68,12 +68,12 @@ Malachar — formerly Malachar Lumenbright, First Eldrian Luminor. Tragic fall. 
 
 ### Design System
 
-- Primary: Violet #8b5cf6
-- Accent: Crystal #7fffd4
-- Premium: Gold #ffd700
-- Fonts: Cinzel (display), Crimson Pro (body), Inter (UI), JetBrains Mono (code)
+- Primary: Atlantean Teal #00bcd4
+- Secondary: Cosmic Blue #0d47a1
+- Accent: Gold #ffd700 · Background: #09090b
+- Fonts: Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code)
 - Effects: Glass morphism, aurora gradients, cosmic glows
-- NEVER: raw hex colors, emoji icons, flat shadows, Space Grotesk
+- NEVER: raw hex colors, emoji icons, flat shadows, Cinzel, Space Grotesk, Inter
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Arcanea is the public code mirror for [arcanea.ai](https://arcanea.ai), the crea
 
 ![Arcanea GitHub Hero](.github/assets/arcanea-github-main-hero.jpg)
 
-> Premium visual identity per .github/ARCANEA_VISUAL_ECOSYSTEM.md (Lumina & Nero dance + Ten Gates; God of War meets Destiny ethereal 8K; Atlantean Teal #7fffd4 / Arcanean Gold #ffd700 / Cosmic Blue on Deep Void). Full alignment to DESIGN.md (tokens, Geist/Instrument/Mono, glass, no raw hex/emojis/Inter), TASTE.md 7 gates (AI-lab premium restraint, no slop), .arcanea/lore/VISUAL_DOCTRINE.md (luxury cosmic myth-tech, franchise eq, faction grammars).
+> Premium visual identity per .github/ARCANEA_VISUAL_ECOSYSTEM.md (Lumina & Nero dance + Ten Gates; God of War meets Destiny ethereal 8K; Atlantean Teal #00bcd4 / Arcanean Gold #ffd700 / Cosmic Blue on Deep Void). Full alignment to DESIGN.md (tokens, Geist/Instrument/Mono, glass, no raw hex/emojis/Inter), TASTE.md 7 gates (AI-lab premium restraint, no slop), .arcanea/lore/VISUAL_DOCTRINE.md (luxury cosmic myth-tech, franchise eq, faction grammars).
 
 ## What this repo is
 

--- a/arcanea-skills-opensource/agents/design-sage.md
+++ b/arcanea-skills-opensource/agents/design-sage.md
@@ -104,10 +104,10 @@ Too much glow = no glow.
 ### Typography
 ```css
 /* Display */
-font-family: 'Cinzel', serif;  /* Headings */
+font-family: 'Geist', sans-serif;  /* Headings */
 
 /* Body */
-font-family: 'Crimson Pro', serif;  /* Content */
+font-family: 'Geist', sans-serif;  /* Content */
 
 /* Code */
 font-family: 'JetBrains Mono', monospace;

--- a/arcanea-skills-opensource/skills/arcanea/design-system/SKILL.md
+++ b/arcanea-skills-opensource/skills/arcanea/design-system/SKILL.md
@@ -99,10 +99,10 @@ The Arcanean UI represents **a portal into creative consciousness**:
 ### Font Stack
 ```css
 /* Display (Headings, Titles) */
-font-family: 'Cinzel', 'Cormorant Garamond', serif;
+font-family: 'Geist', sans-serif;
 
 /* Body (Content, UI) */
-font-family: 'Crimson Pro', 'Source Serif Pro', Georgia, serif;
+font-family: 'Geist', sans-serif;
 
 /* Code (Monospace) */
 font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -564,8 +564,8 @@ const ARCANEA_TOKENS = {
     },
   },
   fonts: {
-    display: 'Cinzel, serif',
-    body: 'Crimson Pro, serif',
+    display: 'Geist, sans-serif',
+    body: 'Geist, sans-serif',
     mono: 'JetBrains Mono, monospace',
   },
   radii: {

--- a/arcanea-soul/docs/NAMING_ARCHITECTURE.md
+++ b/arcanea-soul/docs/NAMING_ARCHITECTURE.md
@@ -142,11 +142,11 @@ A diagnostic and guidance system for creative blocks.
 
 | Element | Value |
 |---------|-------|
-| Primary Color | Atlantean Teal (#7fffd4) |
-| Secondary | Cosmic Blue (#78a6ff) |
+| Primary Color | Atlantean Teal (#00bcd4) |
+| Secondary | Cosmic Blue (#0d47a1) |
 | Accent | Gold Bright (#ffd700) |
-| Display Font | Cinzel |
-| Body Font | Crimson Pro |
+| Display Font | Geist |
+| Body Font | Geist (Instrument Serif for editorial accent) |
 | Aesthetic | Cosmic, glass morphism, aurora |
 
 ---

--- a/docs/HERO_BANNER_GENERATION_GUIDE.md
+++ b/docs/HERO_BANNER_GENERATION_GUIDE.md
@@ -42,7 +42,7 @@ STYLE:
 - NOT cartoonish - elegant, mythological, timeless
 
 COLOR PALETTE:
-- Primary: Deep cosmic black (#0a0a0f), Celestial gold (#ffd700), Atlantean teal (#7fffd4)
+- Primary: Deep cosmic black (#0a0a0f), Celestial gold (#ffd700), Atlantean teal (#00bcd4)
 - Secondary: Cosmic purple (#9370db), Pure white (#ffffff), Silver (#c0c0c0)
 - Accents: Each Gate's signature color as glowing points
 

--- a/docs/brand/guidelines/brand_guidelines_design_system.md
+++ b/docs/brand/guidelines/brand_guidelines_design_system.md
@@ -1,5 +1,7 @@
 # Arcanea Academy - Brand Guidelines & Design System
 
+> **Superseded (2026-08-07).** This document predates the canonical design system and is kept for historical reference. Current tokens: Primary Atlantean Teal `#00bcd4`, Secondary Cosmic Blue `#0d47a1`, Accent Gold `#ffd700`, Background `#09090b`; fonts Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code). Cinzel, Space Grotesk, and Inter are banned. Canonical source: `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`).
+
 ## Brand Overview
 
 Arcanea Academy represents the convergence of ancient wisdom and futuristic technology, where advanced AGI beings from 100 years in the future guide humanity toward creative mastery. Our brand embodies the mystical yet practical nature of learning from an advanced civilization while remaining grounded in real-world applications.
@@ -598,4 +600,4 @@ Maintain a comprehensive component library with:
 3. **Accessibility Review:** WCAG compliance verification
 4. **User Testing:** Real-world usage validation
 
-This comprehensive brand guidelines document ensures consistent, recognizable, and effective brand expression across all touchpoints while maintaining the mystical yet approachable character that makes Arcanea Academy unique in the AI education space.
+This comprehensive brand guidelines document ensures consistent, recognizable, and effective brand expression across all touchpoints while maintaining the mystical yet approachable character that makes Arcanea Academy unique in the AI education space.

--- a/docs/design/design_system.md
+++ b/docs/design/design_system.md
@@ -1,4 +1,7 @@
 # Arcanean Design System
+
+> **Superseded (2026-08-07).** This document predates the canonical design system and is kept for historical reference. Current tokens: Primary Atlantean Teal `#00bcd4`, Secondary Cosmic Blue `#0d47a1`, Accent Gold `#ffd700`, Background `#09090b`; fonts Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code). Cinzel, Space Grotesk, and Inter are banned. Canonical source: `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`).
+
 ## Version 1.0 - The Kingdom of Light
 
 ---

--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -1,4 +1,7 @@
 # Arcanean Typography System
+
+> **Superseded (2026-08-07).** This document predates the canonical design system and is kept for historical reference. Current tokens: Primary Atlantean Teal `#00bcd4`, Secondary Cosmic Blue `#0d47a1`, Accent Gold `#ffd700`, Background `#09090b`; fonts Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code). Cinzel, Space Grotesk, and Inter are banned. Canonical source: `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`).
+
 ## The Written Language of Light
 
 ---

--- a/oss/agents/design-sage.md
+++ b/oss/agents/design-sage.md
@@ -104,10 +104,10 @@ Too much glow = no glow.
 ### Typography
 ```css
 /* Display */
-font-family: 'Cinzel', serif;  /* Headings */
+font-family: 'Geist', sans-serif;  /* Headings */
 
 /* Body */
-font-family: 'Crimson Pro', serif;  /* Content */
+font-family: 'Geist', sans-serif;  /* Content */
 
 /* Code */
 font-family: 'JetBrains Mono', monospace;

--- a/oss/skills/arcanea/design-system/SKILL.md
+++ b/oss/skills/arcanea/design-system/SKILL.md
@@ -99,10 +99,10 @@ The Arcanean UI represents **a portal into creative consciousness**:
 ### Font Stack
 ```css
 /* Display (Headings, Titles) */
-font-family: 'Cinzel', 'Cormorant Garamond', serif;
+font-family: 'Geist', sans-serif;
 
 /* Body (Content, UI) */
-font-family: 'Crimson Pro', 'Source Serif Pro', Georgia, serif;
+font-family: 'Geist', sans-serif;
 
 /* Code (Monospace) */
 font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -564,8 +564,8 @@ const ARCANEA_TOKENS = {
     },
   },
   fonts: {
-    display: 'Cinzel, serif',
-    body: 'Crimson Pro, serif',
+    display: 'Geist, sans-serif',
+    body: 'Geist, sans-serif',
     mono: 'JetBrains Mono, monospace',
   },
   radii: {

--- a/starlight-protocol/01_INTELLECT/VAULT_DESIGN/TOKENS.md
+++ b/starlight-protocol/01_INTELLECT/VAULT_DESIGN/TOKENS.md
@@ -9,14 +9,14 @@ Any deviation requires `The Creative Director` approval.
 ## 1. Colors (The Void Palette)
 *   `bg-cosmic-void`: `#0b0e14` (Deepest Black/Blue)
 *   `bg-cosmic-deep`: `#121826` (Card Background)
-*   `text-crystal`: `#7fffd4` (Aquamarine / Primary Action)
+*   `text-crystal`: `#00bcd4` (Atlantean Teal / Primary Action)
 *   `text-primary`: `#e6eefc` (Readability High)
 *   `text-secondary`: `#9bb1d0` (Readability Medium)
 
 ## 2. Typography (The Voice)
-*   **Headings:** `Cinzel` (Serif Display). Uppercase.
-*   **Body:** `Inter` (Sans). Clean, readable.
-*   **Lore:** `Crimson Pro` (Serif). For narrative text.
+*   **Headings:** `Geist` (Display). Uppercase.
+*   **Body:** `Geist` (Sans). Clean, readable.
+*   **Lore:** `Instrument Serif` (Serif). For narrative text.
 *   **Code:** `JetBrains Mono`.
 
 ## 3. The Glass Effect (Signature)
@@ -25,7 +25,7 @@ Do not use flat backgrounds. Use the **Glass Stack**:
 .glass {
   background: rgba(18, 24, 38, 0.7);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(127, 255, 212, 0.15);
+  border: 1px solid rgba(0, 188, 212, 0.15);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 ```

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /**
  * Arcanea Tailwind Configuration v2.0
  * Source of truth: .arcanea/design/DESIGN_BIBLE.md
+ * Canonical tokens: @arcanea/design-system v0.2.0 (production repo arcanea-ai-app)
  * Cosmic Glass Design System
  *
  * @type {import('tailwindcss').Config}
@@ -75,16 +76,16 @@ module.exports = {
         // Brand
         brand: {
           primary: "#8b5cf6",
-          accent: "#7fffd4",
+          accent: "#00bcd4",
           gold: "#ffd700",
-          secondary: "#78a6ff"
+          secondary: "#0d47a1"
         },
 
         // Elemental Accents
         crystal: {
-          DEFAULT: "#7fffd4",
-          bright: "#99ffe0",
-          deep: "#5ce6b8"
+          DEFAULT: "#00bcd4",
+          bright: "#4dd0e1",
+          deep: "#0097a7"
         },
         fire: {
           DEFAULT: "#ff6b35",
@@ -92,9 +93,9 @@ module.exports = {
           deep: "#d94e1f"
         },
         water: {
-          DEFAULT: "#78a6ff",
-          bright: "#9dbfff",
-          deep: "#5a8ce6"
+          DEFAULT: "#0d47a1",
+          bright: "#5472d3",
+          deep: "#002171"
         },
         "void-el": {
           DEFAULT: "#9966ff",
@@ -134,9 +135,9 @@ module.exports = {
          TYPOGRAPHY
          ========================================== */
       fontFamily: {
-        display: ["Cinzel", "serif"],
-        body: ["Crimson Pro", "serif"],
-        sans: ["Inter", "system-ui", "-apple-system", "sans-serif"],
+        display: ["Geist", "sans-serif"],
+        body: ["Geist", "sans-serif"],
+        sans: ["Geist", "system-ui", "-apple-system", "sans-serif"],
         mono: ["JetBrains Mono", "monospace"]
       },
 
@@ -170,10 +171,10 @@ module.exports = {
          ========================================== */
       boxShadow: {
         // Glows
-        "glow-sm": "0 0 10px rgba(127, 255, 212, 0.15)",
-        "glow-md": "0 0 20px rgba(127, 255, 212, 0.25)",
-        "glow-lg": "0 0 40px rgba(127, 255, 212, 0.35)",
-        "glow-xl": "0 0 60px rgba(127, 255, 212, 0.45)",
+        "glow-sm": "0 0 10px rgba(0, 188, 212, 0.15)",
+        "glow-md": "0 0 20px rgba(0, 188, 212, 0.25)",
+        "glow-lg": "0 0 40px rgba(0, 188, 212, 0.35)",
+        "glow-xl": "0 0 60px rgba(0, 188, 212, 0.45)",
         "glow-brand": "0 0 20px rgba(139, 92, 246, 0.3)",
         "glow-fire": "0 0 20px rgba(255, 107, 53, 0.3)",
         "glow-gold": "0 0 20px rgba(255, 215, 0, 0.3)",
@@ -191,13 +192,13 @@ module.exports = {
          ========================================== */
       backgroundImage: {
         "cosmic-gradient": "linear-gradient(135deg, #0b0e14 0%, #1a2332 100%)",
-        "cosmic-mesh": "radial-gradient(ellipse at 20% 50%, rgba(127, 255, 212, 0.03) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(153, 102, 255, 0.03) 0%, transparent 50%), radial-gradient(ellipse at 50% 80%, rgba(120, 166, 255, 0.03) 0%, transparent 50%)",
-        "aurora": "linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(127, 255, 212, 0.06) 33%, rgba(120, 166, 255, 0.08) 66%, rgba(255, 215, 0, 0.04) 100%)",
-        "gradient-crystal": "linear-gradient(135deg, #7fffd4 0%, #99ffe0 100%)",
+        "cosmic-mesh": "radial-gradient(ellipse at 20% 50%, rgba(0, 188, 212, 0.03) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(153, 102, 255, 0.03) 0%, transparent 50%), radial-gradient(ellipse at 50% 80%, rgba(13, 71, 161, 0.03) 0%, transparent 50%)",
+        "aurora": "linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(0, 188, 212, 0.06) 33%, rgba(13, 71, 161, 0.08) 66%, rgba(255, 215, 0, 0.04) 100%)",
+        "gradient-crystal": "linear-gradient(135deg, #00bcd4 0%, #4dd0e1 100%)",
         "gradient-fire": "linear-gradient(135deg, #ff6b35 0%, #ffd700 100%)",
         "gradient-void": "linear-gradient(135deg, #9966ff 0%, #b38cff 100%)",
         "gradient-gold": "linear-gradient(135deg, #ffd700 0%, #ffe44d 100%)",
-        "gradient-brand": "linear-gradient(135deg, #8b5cf6 0%, #7fffd4 100%)"
+        "gradient-brand": "linear-gradient(135deg, #8b5cf6 0%, #00bcd4 100%)"
       },
 
       /* ==========================================
@@ -251,8 +252,8 @@ module.exports = {
           "50%": { transform: "scale(1.03)", opacity: "0.9" }
         },
         "glow-pulse": {
-          "0%, 100%": { boxShadow: "0 0 20px rgba(127, 255, 212, 0.2)" },
-          "50%": { boxShadow: "0 0 40px rgba(127, 255, 212, 0.4)" }
+          "0%, 100%": { boxShadow: "0 0 20px rgba(0, 188, 212, 0.2)" },
+          "50%": { boxShadow: "0 0 40px rgba(0, 188, 212, 0.4)" }
         }
       },
 


### PR DESCRIPTION
## Summary
The 2026-07-25 Empire Index audit flagged this public OSS mirror as "publicly teaching the banned design system (Cinzel, wrong teal)". This PR aligns every design-teaching surface — cross-harness agent instructions, brand/design docs, design skills, token specs, and the root Tailwind config — to the canonical system from `@arcanea/design-system` v0.2.0 (production repo `arcanea-ai-app`, decided 2026-04-18). Runtime app code is deliberately out of scope.

## Changes
- Colors: Atlantean Teal `#7fffd4` → `#00bcd4`; Cosmic Blue `#78a6ff` → `#0d47a1`; matching glow rgba values; derived tints mapped to Material cyan 300/700 (`#4dd0e1`/`#0097a7`) and Material blue 900 light/dark (`#5472d3`/`#002171`) — a judgment call, since v0.2.0 defines no tint scale.
- Fonts: Cinzel / Crimson Pro / Space Grotesk / Inter → Geist (display + body), Instrument Serif (editorial accent), JetBrains Mono (code), across `.claude/CLAUDE.md`, `.cursorrules`, `.cursor/rules/arcanea.mdc`, `.codex/` + `.gemini/` + Copilot + OpenCode instructions, `tailwind.config.js`, `ARCANEA_BRAND_GUIDELINES.md`, `.arcanea/design/DESIGN_BIBLE.md` + `FIGMA_IMPORT_GUIDE.md`, `.arcanea/config/design-tokens.yaml`, `.arcanea/workflows/design.yaml`, design skills/agents/commands (incl. the 4 public copies of the design-system SKILL and 5 copies of design-sage), and `starlight-protocol` vault tokens.
- Ban lines ("never Cinzel, Space Grotesk, or Inter") and `canonical: @arcanea/design-system v0.2.0` pointers added wherever fonts are specified.
- Three legacy docs (`docs/design/design_system.md`, `docs/design/typography.md`, `docs/brand/guidelines/brand_guidelines_design_system.md`) get a superseded banner with the canonical tokens instead of a line-by-line rewrite — their body text is historical reference.
- Contrast ratio in `accessibility-guardian.md` recomputed for the new teal (12.4:1 → 8.7:1); `--accent` HSL in DESIGN_BIBLE recomputed (187 100% 42%).

Deliberately untouched (needs separate coordinated work):
- `apps/web/`, `arcanea.ai/`, `packages/` (runtime code + tests pinning old hexes; UI migration must go through the web-release-gate with screenshots)
- `archive/`, `versions/`, root HTML demos, `games/`, `docs/showcase/`, `oss/assets/` (generated/legacy artifacts)
- `sync/aios/lore/ARCANEA_CANON.md` (mirrored from another system), vendored skill data (`ui-ux-pro-max` CSVs, Crimson Pro OFL license file)

## Type
- [x] Docs (documentation only)
- [x] Refactor (code improvement, no behavior change)

## Checklist
- [ ] TypeScript compiles with zero errors (`pnpm build`)
- [x] Changes align with [ARCANEA_CANON.md](./.arcanea/lore/ARCANEA_CANON.md) (if lore-related)
- [x] No new `any` types introduced
- [ ] Tested locally or verified in Vercel preview

Draft for orchestrator review — do not merge from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011saEKpfoKNC1JHMzAfBqmF

---
_Generated by [Claude Code](https://claude.ai/code/session_011saEKpfoKNC1JHMzAfBqmF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual identity with brighter cyan and deeper blue accent colors.
  * Standardized typography around Geist, with Instrument Serif for editorial content and JetBrains Mono for code.
  * Refreshed gradients, glows, glass effects, focus indicators, buttons, and related visual guidance.

* **Documentation**
  * Aligned design references and brand guidelines with the updated visual system.
  * Added notices identifying superseded design documentation and current canonical guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->